### PR TITLE
增加去掉後選詞前序號的功能

### DIFF
--- a/SquirrelApplicationDelegate.m
+++ b/SquirrelApplicationDelegate.m
@@ -182,11 +182,14 @@ void notification_handler(void* context_object, RimeSessionId session_id,
 
 -(void)updateUIStyle:(RimeConfig*)config
 {
-  SquirrelUIStyle style = { NO, nil, 0, 1.0, 0.0, 0.0, 0.0, nil, nil, nil, nil, nil };
+  SquirrelUIStyle style = { NO, NO, nil, 0, 1.0, 0.0, 0.0, 0.0, nil, nil, nil, nil, nil };
   
   Bool value = False;
   if (RimeConfigGetBool(config, "style/horizontal", &value)) {
     style.horizontal = (BOOL)value;
+  }
+  if (RimeConfigGetBool(config, "style/nonumber", &value)) {
+    style.nonumber = (BOOL)value;
   }
   
   char font_face[100] = {0};

--- a/SquirrelPanel.h
+++ b/SquirrelPanel.h
@@ -10,6 +10,7 @@
 
 typedef struct {
   BOOL horizontal;
+  BOOL nonumber;
   NSString* fontName;
   int fontSize;
   double alpha;
@@ -31,6 +32,7 @@ typedef struct {
   NSMutableDictionary* _highlightedAttrs;
   NSMutableDictionary* _commentAttrs;
   BOOL _horizontal;
+  BOOL _nonumber;
 }
 
 -(void)show;

--- a/SquirrelPanel.m
+++ b/SquirrelPanel.m
@@ -116,6 +116,7 @@ static const double kAlpha = 1.0;
   [_commentAttrs setObject:[NSFont userFontOfSize:kFontSize] forKey:NSFontAttributeName];
   
   _horizontal = NO;
+  _nonumber = NO;
   return self;
 }
 
@@ -183,11 +184,16 @@ static const double kAlpha = 1.0;
   NSUInteger i;
   for (i = 0; i < [candidates count]; ++i) {
     NSString* str;
-    if (i < [labels length]) {
-      str = [NSString stringWithFormat:@"%c. %@ ", [labels characterAtIndex:i], [candidates objectAtIndex:i]];
+    if (_nonumber) {
+        str = [NSString stringWithFormat:@"%@", [candidates objectAtIndex:i]];
     }
     else {
-      str = [NSString stringWithFormat:@"%ld. %@ ", i + 1, [candidates objectAtIndex:i]];
+        if (i < [labels length]) {
+            str = [NSString stringWithFormat:@"%c. %@ ", [labels characterAtIndex:i], [candidates objectAtIndex:i]];
+        }
+        else {
+            str = [NSString stringWithFormat:@"%ld. %@ ", i + 1, [candidates objectAtIndex:i]];
+        }
     }
     NSMutableAttributedString* line = [[[NSMutableAttributedString alloc] initWithString:str attributes:_attrs] autorelease];
     if (i == index) {
@@ -229,6 +235,7 @@ static const double kAlpha = 1.0;
 -(void)updateUIStyle:(SquirrelUIStyle *)style
 {
   _horizontal = style->horizontal;
+  _nonumber = style->nonumber;
   
   if (style->fontSize == 0) {  // default size
     style->fontSize = kFontSize;

--- a/data/squirrel.yaml
+++ b/data/squirrel.yaml
@@ -10,6 +10,7 @@ show_notifications_when: growl_is_running
 
 style:
   horizontal: false
+  nonumber: false
   #font_face: "儷黑 Pro"
   #font_point: 21
   corner_radius: 10


### PR DESCRIPTION
示例:

![Messages Image 1958707419 ](https://f.cloud.github.com/assets/222272/32768/db281938-503f-11e2-829c-43120a5d1f04.png)

調節參數在squirrel.yaml的style/nonumber中 默認false

如果有用的話, 更進一步可以允許自定義後選詞前綴? 比如' - '等等
