### PR TITLE
A workaround for Input Method Kit's default mouse handling in Safari

### DIFF
--- a/SquirrelInputController.m
+++ b/SquirrelInputController.m
@@ -118,6 +118,11 @@
       }
     }
       break;
+    case NSLeftMouseDown:
+    {
+      [self commitComposition:_currentClient];
+    }
+      break;
     defaults:
       break;
   }
@@ -218,7 +223,7 @@
 -(NSUInteger)recognizedEvents:(id)sender
 {
   //NSLog(@"recognizedEvents:");
-  return NSKeyDownMask | NSFlagsChangedMask;
+  return NSKeyDownMask | NSFlagsChangedMask | NSLeftMouseDownMask;
 }
 
 -(void)activateServer:(id)sender


### PR DESCRIPTION
In Safari, as shown in the following screenshot, when I'm composing something but haven't finished yet, if I click any of those suggested items, I am expecting the browser to redirect me to that particular page. However, what actually happened is that the composing is committed, and then the suggested items changed, which is very inconvenient.

And there is no such issue in Chrome.
This is probably a bug in Safari? The input client (i.e Safari) should handle the left mouse down event before the input method, therefore at the time the input method handles the left mouse down event, the redirection should have already completed.

![Screen Shot 2013-03-26 at 1 16 19 AM](https://f.cloud.github.com/assets/251435/299089/d4a8322a-9570-11e2-91c3-dfaf164af2cb.png)
