### PR TITLE
Fix: Add missing run-path search paths for binary files.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,14 @@ OPENCC_DATA = data/opencc/TSCharacters.ocd data/opencc/TSPhrases.ocd data/opencc
 DEPENDS = $(LIBRIME) $(BRISE) $(OPENCC_DATA)
 
 LIBRIME_OUTPUT = librime/xbuild/lib/Release/librime.1.dylib
-RIME_DEPLOYER_OUTPUT = librime/xbuild/bin/Release/rime_deployer
-RIME_DICT_MANAGER_OUTPUT = librime/xbuild/bin/Release/rime_dict_manager
+RIME_BIN_BUILD_DIR = librime/xbuild/bin/Release
+RIME_BIN_DEPLOYER = rime_deployer
+RIME_BIN_DICT_MANAGER = rime_dict_manager
 OPENCC_DATA_OUTPUT = librime/thirdparty/data/opencc/*.*
 DATA_FILES = brise/default.yaml brise/symbols.yaml brise/essay.txt brise/preset/*.yaml brise/supplement/*.yaml
+
+INSTALL_NAME_TOOL = $(shell xcrun -find install_name_tool)
+INSTALL_NAME_TOOL_ARGS = -add_rpath @loader_path/../Frameworks
 
 $(LIBRIME):
 	$(MAKE) librime
@@ -27,8 +31,10 @@ $(OPENCC_DATA):
 librime:
 	cd librime; make -f Makefile.xcode
 	cp -L $(LIBRIME_OUTPUT) $(LIBRIME)
-	cp $(RIME_DEPLOYER_OUTPUT) bin/
-	cp $(RIME_DICT_MANAGER_OUTPUT) bin/
+	cp $(RIME_BIN_BUILD_DIR)/$(RIME_BIN_DEPLOYER) bin/
+	cp $(RIME_BIN_BUILD_DIR)/$(RIME_BIN_DICT_MANAGER) bin/
+	$(INSTALL_NAME_TOOL) $(INSTALL_NAME_TOOL_ARGS) bin/$(RIME_BIN_DEPLOYER)
+	$(INSTALL_NAME_TOOL) $(INSTALL_NAME_TOOL_ARGS) bin/$(RIME_BIN_DICT_MANAGER)
 
 data: update_brise update_opencc_data
 


### PR DESCRIPTION
This patch eliminates this error when running rime_dict_manager and rime_deployer:

> dyld: Library not loaded: @rpath/librime.1.dylib

According to [Dynamic Library Usage Guidelines](https://developer.apple.com/library/mac/documentation/DeveloperTools/Conceptual/DynamicLibraries/100-Articles/DynamicLibraryUsageGuidelines.html), if users do not set `DYLD_LIBRARY_PATH` properly when no useful run-path search path is set, they cannot run those two binary files successfully. I've also tested with the latest official release. Running the following commands shows that rpath is empty:

```sh
otool -l /Library/Input\ Methods/Squirrel.app/Contents/MacOS/rime_dict_manager | grep -C3 LC_RPATH
otool -l /Library/Input\ Methods/Squirrel.app/Contents/MacOS/rime_deployer | grep -C3 LC_RPATH
```

Although they actually depend on the shared library:

```sh
otool -L /Library/Input\ Methods/Squirrel.app/Contents/MacOS/rime_dict_manager
otool -L /Library/Input\ Methods/Squirrel.app/Contents/MacOS/rime_deployer
```

Output:

```
/Library/Input Methods/Squirrel.app/Contents/MacOS/rime_dict_manager:
	@rpath/librime.1.dylib (compatibility version 1.0.0, current version 1.2.9)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 120.0.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1213.0.0)

/Library/Input Methods/Squirrel.app/Contents/MacOS/rime_deployer:
	@rpath/librime.1.dylib (compatibility version 1.0.0, current version 1.2.9)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 120.0.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1213.0.0)
```

Maybe it should be fixed for the “Release” build in [rime/librime](https://github.com/rime/librime) instead, but I don't see a `make install` command for OSX. The “Debug” build works well, because it has specified the absolute library paths for the executable files (so those files are not for installation).


---
Reference:
1. [Run-Path Dependent Libraries](https://developer.apple.com/library/mac/documentation/DeveloperTools/Conceptual/DynamicLibraries/100-Articles/RunpathDependentLibraries.html)
2. [Dynamic Library Usage Guidelines](https://developer.apple.com/library/mac/documentation/DeveloperTools/Conceptual/DynamicLibraries/100-Articles/DynamicLibraryUsageGuidelines.html)
3. [CMake RPATH handling](http://www.cmake.org/Wiki/CMake_RPATH_handling)