### PR TITLE
当 ~/bin/squirrel_toggle_option文件存在时 toggle option 操作会执行此脚本

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@ LIBRIME = lib/librime.1.dylib
 LIBRIME_DEPS = librime/thirdparty/lib/libmarisa.a librime/thirdparty/lib/libleveldb.a librime/thirdparty/lib/libopencc.a librime/thirdparty/lib/libyaml-cpp.a
 BRISE = data/brise/default.yaml data/brise/symbols.yaml data/brise/essay.txt
 OPENCC_DATA = data/opencc/TSCharacters.ocd data/opencc/TSPhrases.ocd data/opencc/t2s.json
-DEPS = $(LIBRIME) $(BRISE) $(OPENCC_DATA)
-
+SQUIRREL_CLIENT=squirrel_client
+DEPS = $(LIBRIME) $(BRISE) $(OPENCC_DATA) $(SQUIRREL_CLIENT)
 LIBRIME_OUTPUT = librime/xbuild/lib/Release/librime.1.dylib
 RIME_BIN_BUILD_DIR = librime/xbuild/bin/Release
 RIME_BIN_DEPLOYER = rime_deployer
@@ -40,6 +40,8 @@ librime: $(LIBRIME_DEPS)
 	$(INSTALL_NAME_TOOL) $(INSTALL_NAME_TOOL_ARGS) bin/$(RIME_BIN_DICT_MANAGER)
 
 data: update_brise update_opencc_data
+squirrel_client:
+	clang SquirrelClient.c -o ./bin/squirrel_client
 
 update_brise:
 	mkdir -p data/brise
@@ -50,7 +52,7 @@ update_opencc_data:
 	mkdir -p data/opencc
 	cp $(OPENCC_DATA_OUTPUT) data/opencc/
 
-deps: librime data
+deps: librime data squirrel_client
 
 release: $(DEPS)
 	xcodebuild -project Squirrel.xcodeproj -configuration Release build | grep -v setenv | tee build.log

--- a/Squirrel.xcodeproj/project.pbxproj
+++ b/Squirrel.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1B4763F11DAA029B00C58621 /* SquirrelDomainServer.m in Sources */ = {isa = PBXBuildFile; fileRef = 1B4763F01DAA029B00C58621 /* SquirrelDomainServer.m */; };
+		1BC8F63A1DAA515700461284 /* squirrel_client in Resources */ = {isa = PBXBuildFile; fileRef = 1BC8F6391DAA515700461284 /* squirrel_client */; };
+		1BC8F63B1DAA516200461284 /* squirrel_client in CopyFiles */ = {isa = PBXBuildFile; fileRef = 1BC8F6391DAA515700461284 /* squirrel_client */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		442B5B881570C37200370DEA /* squirrel.yaml in Copy Shared Support Files */ = {isa = PBXBuildFile; fileRef = 442B5B871570C37200370DEA /* squirrel.yaml */; };
 		4443A83A1828CC5100731305 /* input_source.m in Sources */ = {isa = PBXBuildFile; fileRef = 4443A8391828CC5100731305 /* input_source.m */; };
 		448CCCDD166B2E0500337E78 /* Growl Registration Ticket.growlRegDict in Resources */ = {isa = PBXBuildFile; fileRef = 448CCCDC166B2E0500337E78 /* Growl Registration Ticket.growlRegDict */; };
@@ -207,6 +210,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 6;
 			files = (
+				1BC8F63B1DAA516200461284 /* squirrel_client in CopyFiles */,
 				44E21A9016A653E700C2B08F /* rime_deployer in CopyFiles */,
 				44E21A9116A653E700C2B08F /* rime_dict_manager in CopyFiles */,
 			);
@@ -230,6 +234,9 @@
 /* Begin PBXFileReference section */
 		089C165DFE840E0CC02AAC07 /* English */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = English; path = English.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = /System/Library/Frameworks/Cocoa.framework; sourceTree = "<absolute>"; };
+		1B4763F01DAA029B00C58621 /* SquirrelDomainServer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SquirrelDomainServer.m; sourceTree = "<group>"; };
+		1B4763F21DAA03D100C58621 /* SquirrelDomainServer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SquirrelDomainServer.h; sourceTree = "<group>"; };
+		1BC8F6391DAA515700461284 /* squirrel_client */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.executable"; name = squirrel_client; path = bin/squirrel_client; sourceTree = "<group>"; };
 		29B97316FDCFA39411CA2CEA /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		29B97324FDCFA39411CA2CEA /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = /System/Library/Frameworks/AppKit.framework; sourceTree = "<absolute>"; };
 		29B97325FDCFA39411CA2CEA /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = /System/Library/Frameworks/Foundation.framework; sourceTree = "<absolute>"; };
@@ -383,6 +390,8 @@
 				44F84AD614E94C490005D70B /* SquirrelPanel.m */,
 				7BDB21211C6EF1BE0025E351 /* SquirrelConfig.h */,
 				7BDB21221C6EF1BE0025E351 /* SquirrelConfig.m */,
+				1B4763F01DAA029B00C58621 /* SquirrelDomainServer.m */,
+				1B4763F21DAA03D100C58621 /* SquirrelDomainServer.h */,
 			);
 			name = Sources;
 			sourceTree = "<group>";
@@ -420,6 +429,7 @@
 		29B97314FDCFA39411CA2CEA /* Squirrel */ = {
 			isa = PBXGroup;
 			children = (
+				1BC8F6391DAA515700461284 /* squirrel_client */,
 				44E21A8E16A653E700C2B08F /* rime_deployer */,
 				44E21A8F16A653E700C2B08F /* rime_dict_manager */,
 				44DA7A4214DD598900C1ED3B /* SharedSupport */,
@@ -629,6 +639,7 @@
 				A45578F51146A75200592C6E /* MainMenu.xib in Resources */,
 				A4FC48CB0F6530EF0069BE81 /* Localizable.strings in Resources */,
 				44986A95184B421700B3278D /* LICENSE.txt in Resources */,
+				1BC8F63A1DAA515700461284 /* squirrel_client in Resources */,
 				44986A96184B421700B3278D /* README.md in Resources */,
 				44943BB815066A540005EE85 /* postflight in Resources */,
 				44F7708F152B3334005CF491 /* dsa_pub.pem in Resources */,
@@ -648,6 +659,7 @@
 			files = (
 				7BDB21231C6EF1BE0025E351 /* SquirrelConfig.m in Sources */,
 				8D11072D0486CEB800E47090 /* main.m in Sources */,
+				1B4763F11DAA029B00C58621 /* SquirrelDomainServer.m in Sources */,
 				A47C48DF105E8CE8006D528B /* macos_keycode.m in Sources */,
 				44AC951A1430CF6000C888FB /* SquirrelApplicationDelegate.m in Sources */,
 				44AC951B1430CF6000C888FB /* SquirrelInputController.m in Sources */,

--- a/SquirrelApplicationDelegate.m
+++ b/SquirrelApplicationDelegate.m
@@ -109,6 +109,9 @@ void notification_handler(void* context_object, RimeSessionId session_id,
       bool is_ascii_mode = (message_value[0] != '!');
       if (is_ascii_mode != was_ascii_mode) {
         was_ascii_mode = is_ascii_mode;
+
+        toggle_option_hook(context_object,session_id,message_value);
+
         show_status_message(message_value, message_type);
       }
     }
@@ -120,10 +123,25 @@ void notification_handler(void* context_object, RimeSessionId session_id,
              !strcmp(message_value, "!simplification") ||
              !strcmp(message_value, "extended_charset") ||
              !strcmp(message_value, "!extended_charset")) {
+      toggle_option_hook(context_object,session_id,message_value);
       show_status_message(message_value, message_type);
     }
   }
 }
+void toggle_option_hook(void* context_object, RimeSessionId session_id,
+                        const char* message_value) {
+  NSString *toggleHookCmd=(@"~/bin/squirrel_toggle_option").stringByStandardizingPath;
+  NSFileManager *fileManager = [NSFileManager defaultManager];
+
+  if ([fileManager fileExistsAtPath:toggleHookCmd]){
+    [[NSTask launchedTaskWithLaunchPath:toggleHookCmd arguments:@[[NSString stringWithUTF8String:message_value]]] waitUntilExit];
+    // NSString *fullCmd=[NSString stringWithFormat:@"%@ %s" ,toggleHookCmd ,message_value];
+    // system([fullCmd cStringUsingEncoding:NSUTF8StringEncoding]);
+
+
+  }
+}
+
 
 -(void)setupRime
 {
@@ -288,4 +306,3 @@ static BOOL OSVersionIsEqualOrAbove(NSInteger versionMajor, NSInteger versionMin
 }
 
 @end
-

--- a/SquirrelClient.c
+++ b/SquirrelClient.c
@@ -1,0 +1,150 @@
+/* -*- coding:utf-8-unix -*- */
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <stddef.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+#include <getopt.h>
+
+char *socket_path="/tmp/squirrel.sock";
+
+void usage(char **argv){
+  printf ("%s\n",argv[0]);
+
+  printf ("set option:\n");
+  printf ("    -s option_name \n\n");
+
+  printf ("unset option:\n");
+  printf ("    -u option_name\n\n");
+
+  printf ("toggle option:\n");
+  printf ("    -t option_name\n\n");
+
+  printf ("clear composition:\n");
+  printf ("    -c or --clear\n\n");
+
+  printf("options: ascii_mode,full_shape,ascii_punct,simplification,extended_charset\n");
+  printf ("demo: -s ascii_mode\n");
+  printf ("      -u ascii_mode\n");
+  printf ("      -t ascii_mode\n");
+  printf ("      -t ascii_mode --clear\n");
+
+
+
+}
+
+/* send cmd by unix domain socket to squirrel */
+int sendCmd(char *buf){
+  int fd;
+  int n;
+  struct sockaddr_un un;
+
+  if ((fd = socket(AF_UNIX, SOCK_STREAM, 0)) < 0) {
+    perror("socket error");
+    return 1;
+  }
+
+  memset(&un, 0, sizeof(un));
+  un.sun_family = AF_UNIX;
+  strncpy(un.sun_path, socket_path, sizeof(un.sun_path) - 1);
+
+  if (connect(fd, (struct sockaddr *) &un, sizeof(un)) < 0) {
+    perror("connect error");
+    close(fd);
+    return 2;
+  }
+
+  n=write(fd, buf, strlen(buf)) ;
+  if  (n<0){
+    perror("write error");
+    close(fd);
+    return 3;
+  }
+  /* printf ("write%d\n",n); */
+  close(fd);
+
+  return 0;
+}
+
+#define BUF_LEN 512
+
+char* const short_options = "s:t:u:c";
+struct option long_options[] = {
+  { "set",         required_argument,   NULL,    's'     },
+  { "toggle",      required_argument,   NULL,    't'     },
+  { "unset",       required_argument,   NULL,    'u'     },
+  /* { "commit_code", no_argument,         NULL,    'D'     }, */
+  /* { "commit_text", no_argument,         NULL,    'T'     }, */
+  { "clear",       no_argument,         NULL,    'c'     },
+  { NULL,          0,                   NULL,     0      }
+};
+
+int main(int argc, char **argv) {
+  char buf[BUF_LEN];
+  int ch;
+  int handled=0;
+
+  opterr = 0;
+  if (argc == 1){
+    usage(argv);
+    exit(0);
+  }
+  buf[0]='\0';
+  while((ch = getopt_long (argc, argv, short_options, long_options, NULL)) != -1){
+    handled=0;
+    switch(ch) {
+    case 's':
+      strcpy(buf+strlen(buf), "--set,");
+      strncpy(buf+strlen(buf), optarg, sizeof(buf)-strlen(buf) - 1);
+      /* printf ("--set: %s\n",buf); */
+      handled=1;
+      break;
+    case 'u':
+      strcpy(buf+strlen(buf), "--unset,");
+      strncpy(buf+strlen(buf), optarg, sizeof(buf)-strlen(buf) - 1);
+      /* printf ("--unset: %s\n",buf); */
+      handled=1;
+      break;
+    case 't':
+      strcpy(buf+strlen(buf), "--toggle,");
+      strncpy(buf+strlen(buf), optarg, sizeof(buf)-strlen(buf) - 1);
+      /* printf ("--toggle: %s\n",buf); */
+      handled=1;
+      break;
+    /* case 'D': */
+    /*   strncpy(buf+strlen(buf), "--commit_code", sizeof(buf)-strlen(buf) - 1); */
+    /*   /\* printf ("--commit_code: %s\n",buf); *\/ */
+    /*   handled=1; */
+    /*   break; */
+    /* case 'T': */
+    /*   strncpy(buf+strlen(buf), "--commit_text", sizeof(buf)-strlen(buf) - 1); */
+    /*   /\* printf ("--commit_text: %s\n",buf); *\/ */
+    /*   handled=1; */
+    /*   break; */
+    case 'c':
+
+      strncpy(buf+strlen(buf), "--clear", sizeof(buf)-strlen(buf) - 1);
+      /* printf ("--clear: %s\n",buf); */
+      handled=1;
+      break;
+    default:
+      printf("unknow option :%c\n", ch);
+      usage(argv);
+      exit(-1);
+    }
+    if(handled){
+      strcpy(buf+strlen(buf), ",");
+    }
+  }
+  if(strlen(buf)>0){
+    strcpy(buf+strlen(buf)-1, "\0"); /* 去除末尾的分隔符 */
+    if(strlen(buf)>0){
+      /* printf ("%s\n",buf); */
+      sendCmd(buf);
+    }
+  }
+
+}

--- a/SquirrelDomainServer.h
+++ b/SquirrelDomainServer.h
@@ -1,0 +1,19 @@
+#import <Foundation/Foundation.h>
+#import "SquirrelInputController.h"
+
+#import <rime_api.h>
+
+@interface SquirrelDomainServer : NSObject
+
+
++ (id)sharedInstance;
+
+- (instancetype)init __attribute__((unavailable("Cannot use init for this class, use +(SquirrelDomainServer*)sharedInstance instead!")));
+// NOTE: __attribute__ unavailable can NOT lead compile error of dynamic invocation @selector(performSelector:) of Class
+
+// -(int)updateLastSession:(RimeSessionId)session app:(NSString*)currentApp;
+-(int)updateLastSession:(SquirrelInputController*)inputController session:(RimeSessionId)session app:(NSString*)currentApp;
+-(void)destroySession:(RimeSessionId)session;
+
+@end
+

--- a/SquirrelDomainServer.m
+++ b/SquirrelDomainServer.m
@@ -1,0 +1,183 @@
+
+#import <Foundation/Foundation.h>
+#import "SquirrelDomainServer.h"
+
+
+#import <rime_api.h>
+#import <sys/socket.h>
+#import <sys/un.h>
+
+#define QLEN 8
+@implementation SquirrelDomainServer{
+
+  RimeSessionId _session;
+  NSString *_currentApp;
+  SquirrelInputController* _lastInputController;
+
+
+}
+
+
+#pragma mark Singleton Methods
+
++ (id)sharedInstance {
+    static SquirrelDomainServer *sharedMyInstance = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        sharedMyInstance = [[self alloc] init];
+    });
+    return sharedMyInstance;
+}
+
+- (id)init {
+    if (self = [super init]) {
+      NSThread *domainServerThread = [ [NSThread alloc] initWithTarget:self
+                                                     selector:@selector( domainServer )
+                                                       object:nil ];
+      [domainServerThread start ];
+    }
+    return self;
+}
+
+- (void)dealloc {
+    // Should never be called, but just here for clarity really.
+}
+
+-(int)updateLastSession:(SquirrelInputController*)inputController session:(RimeSessionId)session app:(NSString*)currentApp{
+  _lastInputController=inputController;
+  _session=session;
+  _currentApp=currentApp;
+  // NSLog(@"update app=%@\n",_currentApp);
+
+}
+-(void)destroySession:(RimeSessionId)session{
+  if (session==_session) {
+    _session=0;
+  }
+}
+// start an unix domain socket to talk with command line tool
+// you can control squirrel by command line
+-(int)domainServer{
+  int fd, clifd, n;
+  struct sockaddr_un un;
+  char buf[512];
+  char *ptr;
+  char *token;
+  char *domainSocketPath="/tmp/squirrel.sock";
+
+
+  if ((fd = socket(AF_UNIX, SOCK_STREAM, 0)) < 0) {
+    NSLog(@"domainServer().socket() error");
+    return 1;
+  }
+
+  memset(&un, 0, sizeof(un));
+  un.sun_family = AF_UNIX;
+  strncpy(un.sun_path, domainSocketPath, sizeof(un.sun_path) - 1);
+  unlink(domainSocketPath);
+
+  if (bind(fd, (struct sockaddr *) &un, sizeof(un)) < 0) {
+    NSLog(@"domainServer().bind() error");
+    return 2;
+  }
+
+  NSLog(@"UNIX Domain Socket bound at:%s\n",domainSocketPath);
+
+  memset(&buf, 0, sizeof(buf));
+
+  if (listen(fd, QLEN) < 0) {
+    NSLog(@"UNIX Domain Socket listen error\n");
+    return 3;
+  }
+
+  while (1) {
+    if ((clifd = accept(fd, NULL, NULL)) == -1) {
+      NSLog(@"UNIX Domain Socket accept error\n");
+      continue;
+    }
+    token=NULL;
+    ptr=NULL;
+
+
+    // while ((n = read(clifd, buf, sizeof(buf))) > 0) {
+    n = read(clifd, buf, sizeof(buf)) ;
+    if (n == -1) {
+      continue;
+    }else if (n>=sizeof(buf)){ // buf is full (it should not)
+      close(clifd);
+      continue;
+    }else{
+      buf[n]='\0';
+    }
+    // NSLog(@"%s %ld %d %d\n",buf,sizeof(buf),strlen(buf),n);
+    if (strlen(buf)<1) {
+      close(clifd);
+      continue;
+    }
+
+    if (_session) {
+      ptr=buf;
+      token=strsep( &ptr,",");
+      while(token!=NULL){
+        if (strcmp("--set" ,token)==0) { // set option
+          token=strsep( &ptr,",");
+          if (token!=NULL) {
+            rime_get_api()->set_option(_session, token, True);
+          }
+
+          token=strsep( &ptr,",");
+        }else if (strcmp("--unset" ,token)==0) { // unset option
+          token=strsep( &ptr,",");
+          if (token!=NULL) {
+            rime_get_api()->set_option(_session, token, False);
+          }
+          token=strsep( &ptr,",");
+        }else if (strcmp("--toggle" ,token)==0) { // toggle option
+          token=strsep( &ptr,",");
+          if (token!=NULL) {
+            rime_get_api()->set_option(_session, token, !(rime_get_api()->get_option(_session,token)));
+          }
+          token=strsep( &ptr,",");
+        }else if (strcmp("--clear" ,token)==0) { // clear
+          [_lastInputController clearComposition];
+          token=strsep( &ptr,",");
+        // if (strcmp("--commit_code" ,token)==0) { // commit_code
+        //   RIME_STRUCT(RimeContext, ctx);
+        //   if (rime_get_api()->get_context(_session, &ctx)) {
+        //     ctx->ClearNonConfirmedComposition();
+        //     ctx->Commit();
+        //     rime_get_api()->free_context(&ctx);
+        //   }
+        // token=strsep( &ptr,",");
+
+        //   continue;
+        // }
+        // if (strcmp("--commit_text" ,token)==0) { // commit_text
+        //   RIME_STRUCT(RimeContext, ctx);
+        //   if (rime_get_api()->get_context(_session, &ctx)) {
+        //     ctx->ConfirmCurrentSelection();
+        //     rime_get_api()->free_context(&ctx);
+        //   }
+        // token=strsep( &ptr,",");
+        //   continue;
+        // }
+
+        }else{
+          token=strsep( &ptr,",");
+        }
+
+      }
+      [_lastInputController rimeUpdate];
+    }
+    close(clifd);
+  }
+  NSLog(@"thread shutdown\n");
+
+
+  return 0;
+
+}
+
+
+
+@end

--- a/SquirrelInputController.h
+++ b/SquirrelInputController.h
@@ -2,5 +2,6 @@
 #import <InputMethodKit/InputMethodKit.h>
 
 @interface SquirrelInputController : IMKInputController
-
+-(void)rimeUpdate;
+-(void)clearComposition;
 @end

--- a/SquirrelInputController.m
+++ b/SquirrelInputController.m
@@ -1,5 +1,6 @@
 #import "SquirrelInputController.h"
 
+#import "SquirrelDomainServer.h"
 #import "SquirrelApplicationDelegate.h"
 #import "SquirrelConfig.h"
 #import "SquirrelPanel.h"
@@ -32,6 +33,8 @@
   NSTimer *_chordTimer;
   NSTimeInterval _chordDuration;
   NSString *_currentApp;
+
+  SquirrelDomainServer *_domainServerInstance;
 }
 
 /*!
@@ -256,6 +259,7 @@
     [sender overrideKeyboardWithKeyboardNamed:@"com.apple.keylayout.US"];
   }
   _preeditString = @"";
+  [_domainServerInstance updateLastSession:self session:_session app:_currentApp];
 }
 
 -(instancetype)initWithServer:(IMKServer*)server delegate:(id)delegate client:(id)inputClient
@@ -265,6 +269,8 @@
     _currentClient = inputClient;
     [self createSession];
   }
+
+  _domainServerInstance=[SquirrelDomainServer sharedInstance];
   return self;
 }
 
@@ -298,6 +304,16 @@
     [self rimeConsumeCommittedText];
   }
 }
+-(void)clearComposition
+{
+  if (_session) {
+    rime_get_api()->clear_composition(_session);
+  }
+
+  [NSApp.squirrelAppDelegate.panel hide];
+}
+
+
 
 // a piece of comment from SunPinyin's macos wrapper says:
 // > though we specified the showPrefPanel: in SunPinyinApplicationDelegate as the
@@ -423,7 +439,7 @@
   NSLog(@"createSession: %@", app);
   _currentApp = [app copy];
   _session = rime_get_api()->create_session();
-  
+
   _schemaId = nil;
 
   if (_session) {
@@ -450,6 +466,7 @@
   //NSLog(@"destroySession:");
   if (_session) {
     rime_get_api()->destroy_session(_session);
+    [_domainServerInstance destroySession:_session];
     _session = 0;
   }
   [self clearChord];


### PR DESCRIPTION
比如当切换中英文状态时
如果~/bin/squirrel_toggle_option 存在并有可执行权限 则会调用此脚本 并且传递一个参数
"ascii_mode" 或者”!ascii_mode" 用来表明当前中英文状态

这个机制可以给用户一个机会，当切换中英文状态时执行一定的操作（如vim 进入insert模式，或emacs 的evil-mode 进入insert state)
也可以在这个脚本中记录输入法的中英文状态，以便外部程序查看

比如结合[Hammerspoon http://www.hammerspoon.org] 可以实现在emacs中当输入法切换成中文时自动进入evil-mode的insert 模式

~/bin/squirrel_toggle_option
```
#!/bin/sh
# accept one param
# it may be [ascii_mode !ascii_mode,
# full_shape, !full_shape ,
# ascii_punct,!ascii_punct,
# simplification !simplification,
# extended_charset !extended_charset]
# 
# http://www.hammerspoon.org
if [ $1=="!ascii_mode" ]; then
    # 切换到中文的时候调用hammerspoon中绑定的一个函数，
    # 在那里做处理
    # 主要判断 当前激活的窗口是不是emacs,如果是emacs ,
   # 模拟按键 使emacs 进入evil-insert-state态
    open -g "hammerspoon://emacs_evil_insert_state"
fi
```



在~/.hammerspoon/init.lua文件中加入以下代码 （前提是装了https://github.com/Hammerspoon/hammerspoon/releases ）

```

-- 主要用来实现 当输入法开始进入中文模式时，使用emacs 自动进入evil-insert-state(相当于vim中进入insert mode)
-- 在当在emacs中编辑文件时，模拟按下f18键，以使emacs 进入evil-insert-state状态
function emacs_evil_insert_state()
   local win = hs.window.frontmostWindow()
   if win ==nil then
      return
   end
   local app = win:application()
   if app:bundleID()=="org.gnu.Emacs" then
      -- emacs 中f18 绑定为进入evil-insert-state
      -- 此处模拟在emacs 中按f18键

      -- (global-set-key (kbd "<f18>") 'evil-insert-state) 
      -- (define-key isearch-mode-map (kbd "<f18>") 'evil-insert-state)

      hs.eventtap.keyStroke({}, "f18")
   elseif app:bundleID()=="com.googlecode.iterm2" then -- 如果是在终端下，通过终端的窗口标题来区分当前是否在用emacs编辑文件
      -- 如果是在iterm2终端中，也模拟按下f18键，
      -- hs.alert.show(win:title())
      if string.match(win:title(), " em ") then -- em is an emacsclient wrapper
         hs.eventtap.keyStroke({}, "f18")
      elseif string.match(win:title(), " emacs ") then
         hs.eventtap.keyStroke({}, "f18")
      elseif string.match(win:title(), " emacsclient ") then
         hs.eventtap.keyStroke({}, "f18")
      elseif string.match(win:title(), " vim ") then
         -- do something when you edit file using vim in iterm
      end
   end
end
 --可以在外部通过 open -g "hammerspoon://emacs_evil_insert_state" 执行这个函数
hs.urlevent.bind("emacs_evil_insert_state", function() emacs_evil_insert_state() end)
```
emacs 中加入f18的按键绑定
```
(global-set-key (kbd "<f18>") 'evil-insert-state)
(define-key isearch-mode-map (kbd "<f18>") 'evil-insert-state) 
```