### PR TITLE
make ascii_mode global across applications

### DIFF
--- a/SquirrelApplicationDelegate.m
+++ b/SquirrelApplicationDelegate.m
@@ -54,6 +54,8 @@ static void show_status_message(const char* msg_text, const char* msg_id) {
   }
 }
 
+extern BOOL _globalAsciiMode = false;
+
 void notification_handler(void* context_object, RimeSessionId session_id,
                           const char* message_type, const char* message_value) {
   if (!strcmp(message_type, "deploy")) {
@@ -88,6 +90,7 @@ void notification_handler(void* context_object, RimeSessionId session_id,
         !strcmp(message_value, "!ascii_mode")) {
       static bool was_ascii_mode = false;
       bool is_ascii_mode = (message_value[0] != '!');
+      _globalAsciiMode = is_ascii_mode;
       if (is_ascii_mode != was_ascii_mode) {
         was_ascii_mode = is_ascii_mode;
         show_status_message(message_value, message_type);

--- a/SquirrelInputController.m
+++ b/SquirrelInputController.m
@@ -34,6 +34,7 @@
   NSString *_currentApp;
 }
 
+extern BOOL _globalAsciiMode;
 /*!
  @method
  @abstract   Receive incoming event
@@ -108,7 +109,13 @@
         [self rimeUpdate];
       } break;
       case NSKeyDown: {
-        // ignore Command+X hotkeys.
+
+	if (rime_get_api()->get_option(_session, "ascii_mode") != _globalAsciiMode) {
+	  rime_get_api()->set_option(_session, "ascii_mode", _globalAsciiMode);
+	  NSLog(@"ascii_mode fucks");
+	}
+
+	// ignore Command+X hotkeys.
         if (modifiers & OSX_COMMAND_MASK)
           break;
 


### PR DESCRIPTION
Tested on macos 10.13.4

Cohesive ascii state will make intuition right. Some guys (including me) like it working this way.

![invitersync](https://user-images.githubusercontent.com/2293057/38743863-c2d36bc6-3f72-11e8-8c6f-95a96b964d03.gif)
