### PR TITLE
checkout submodule

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -39,6 +39,7 @@ port install boost -no_static
 
 ``` sh
 git clone --recursive https://github.com/rime/squirrel.git
+git submodule update --init
 ```
 
 ### Build dependencies


### PR DESCRIPTION
Without 'git submodule update --init',  compiling failed on macOS 10.13.4