### PR TITLE
fix hilight area caculate

### DIFF
--- a/SquirrelPanel.m
+++ b/SquirrelPanel.m
@@ -67,7 +67,7 @@ static NSUInteger highlightedIndex = 0;
     stripRect.origin.x -= separatorWidth/2;
     stripRect.size.height += edgeHeight*2;
     if (highlightedIndex == 0) {
-      stripRect.origin.x = stripRect.origin.x - edgeWidth + separatorWidth/2;
+      stripRect.origin.x = stripRect.origin.x - edgeWidth;
       stripRect.size.width += edgeWidth;
     }
     if (highlightedIndex == numCandidates -1) {

--- a/SquirrelPanel.m
+++ b/SquirrelPanel.m
@@ -6,6 +6,9 @@ static const int kOffsetHeight = 5;
 static const int kDefaultFontSize = 24;
 static const NSTimeInterval kShowStatusDuration = 1.2;
 static NSString *const kDefaultCandidateFormat = @"%c. %@";
+static CGFloat separatorWidth = 0;
+static NSUInteger numCandidates = 0;
+static NSUInteger highlightedIndex = 0;
 
 @interface SquirrelView : NSView
 
@@ -29,7 +32,7 @@ static NSString *const kDefaultCandidateFormat = @"%c. %@";
   self = [super initWithFrame:frameRect];
   if (self) {
     self.wantsLayer = YES;
-    self.layer.masksToBounds = YES;
+    // self.layer.masksToBounds = YES;
   }
   return self;
 }
@@ -60,21 +63,15 @@ static NSString *const kDefaultCandidateFormat = @"%c. %@";
     CGFloat edgeWidth = self.edgeInset.width + 1;
     CGFloat edgeHeight = self.edgeInset.height + 1;
     NSRect stripRect = self.highlightedRect;
-    if (NSMinX(stripRect) - FLT_EPSILON < 0) {
+    stripRect.origin.x += edgeWidth;
+    stripRect.origin.x -= separatorWidth/2;
+    stripRect.size.height += edgeHeight*2;
+    if (highlightedIndex == 0) {
+      stripRect.origin.x = stripRect.origin.x - edgeWidth + separatorWidth/2;
       stripRect.size.width += edgeWidth;
-    } else {
-      stripRect.origin.x += edgeWidth;
     }
-    if (NSMaxX(stripRect) + FLT_EPSILON > NSWidth(self.bounds) - edgeWidth) {
-      stripRect.size.width += edgeWidth;
-    }
-    if (NSMinY(stripRect) - FLT_EPSILON < 0) {
-      stripRect.size.height += edgeHeight;
-    } else {
-      stripRect.origin.y += edgeHeight;
-    }
-    if (NSMaxY(stripRect) + FLT_EPSILON > NSHeight(self.bounds) - edgeHeight) {
-      stripRect.size.height += edgeHeight;
+    if (highlightedIndex == numCandidates -1) {
+      stripRect.size.width += edgeWidth + separatorWidth/2;
     }
     [self.highlightedStripColor setFill];
     NSRectFill(stripRect);
@@ -214,7 +211,8 @@ static NSString *const kDefaultCandidateFormat = @"%c. %@";
            comments:(NSArray *)comments
              labels:(NSString *)labels
         highlighted:(NSUInteger)index {
-  NSUInteger numCandidates = candidates.count;
+  highlightedIndex = index;
+  numCandidates = candidates.count;
   if (numCandidates || (preedit && preedit.length)) {
     _statusMessage = nil;
     if (_statusTimer) {
@@ -321,7 +319,6 @@ static NSString *const kDefaultCandidateFormat = @"%c. %@";
   }
 
   NSRect highlightedRect = NSZeroRect;
-  CGFloat separatorWidth = 0;
 
   // candidates
   NSUInteger i;


### PR DESCRIPTION
Signed-off-by: xiehuc <xiehuc@gmail.com>

之前的计算感觉完全没看懂, 另外为了定位index, 使用太多浮点计算, 不稳定。

输入法是单例，所以将index放在全局变量中感觉并无问题。

修正后的效果如图

![2018-10-01 12 17 10](https://user-images.githubusercontent.com/571878/46269477-fc52dd00-c573-11e8-84f1-a427cbf0823c.png)

![2018-10-01 12 17 16](https://user-images.githubusercontent.com/571878/46269479-ffe66400-c573-11e8-98a0-3ceab5d07f1b.png)

![2018-10-01 12 17 21](https://user-images.githubusercontent.com/571878/46269483-04128180-c574-11e8-853f-8c10903fdb37.png)

修正前的效果：

![2018-10-01 12 06 37](https://user-images.githubusercontent.com/571878/46269327-01635c80-c573-11e8-83f1-5940367b2db5.png)

![2018-10-01 12 08 28](https://user-images.githubusercontent.com/571878/46269323-f90b2180-c572-11e8-8bec-a081ed795745.png)

![2018-10-01 12 07 05](https://user-images.githubusercontent.com/571878/46269329-06c0a700-c573-11e8-8118-af71381cfc09.png)
