### PR TITLE
fix highlighted area small gap

### DIFF
--- a/SquirrelPanel.m
+++ b/SquirrelPanel.m
@@ -61,6 +61,13 @@ static NSString *const kDefaultCandidateFormat = @"%c. %@";
     CGFloat edgeWidth = self.edgeInset.width;
     CGFloat edgeHeight = self.edgeInset.height;
     NSRect stripRect = self.highlightedRect;
+    // line.size.width 是一个浮点数,
+    // 算得的window size 也是浮点数,
+    // 但是 setFrame 函数会扩充成整数,
+    // width = ceil(width) 或者 +1 都可以解决
+    // 选用ceil, 后面的计算都不会带有小数, 计算更简单
+    stripRect.size.width = ceil(stripRect.size.width);
+
     if (NSMinX(stripRect) - FLT_EPSILON < 0) {
       stripRect.size.width += edgeWidth - self.hilitedCornerRadius;
       stripRect.origin.x += self.hilitedCornerRadius;


### PR DESCRIPTION
fix highlighted rect float point calc

fix #240 

line width 会有一个浮点
![image](https://user-images.githubusercontent.com/571878/49511147-4d10ea00-f8c5-11e8-8ffa-21cef77a6e47.png)
算得的window size也是浮点的，
但是 setFrame函数会自动的扩大到整数。

208行
  NSLog(@"window size: %lf", windowRect.size.width);
  [_window setFrame:windowRect display:YES];
  NSLog(@"window size: %lf", _window.frame.size.width);

![image](https://user-images.githubusercontent.com/571878/49511204-7762a780-f8c5-11e8-8ea0-09ece3b90630.png)

所以会造成一个小于1的小间隙。width加1或者是ceil函数都可以。
