### PR TITLE
Add `vim_mode` app option for editor that has vim plugin

### DIFF
--- a/SquirrelInputController.m
+++ b/SquirrelInputController.m
@@ -166,10 +166,11 @@
                                          rime_keycode == XK_bracketleft));
     if (isVimBackInCommandMode) {
       NSString* app = [_currentClient bundleIdentifier];
-      if ([app isEqualToString:@"org.vim.MacVim"] &&
-          !rime_get_api()->get_option(_session, "ascii_mode")) {
+      SquirrelAppOptions *appOptions = [NSApp.squirrelAppDelegate.config getAppOptions:app.copy];
+      BOOL vimMode = appOptions[@"vim_mode"].boolValue;
+      if (vimMode && !rime_get_api()->get_option(_session, "ascii_mode")) {
         rime_get_api()->set_option(_session, "ascii_mode", True);
-        NSLog(@"disable conversion to Chinese in MacVim's command mode");
+        NSLog(@"disable conversion to Chinese in Editor's command mode when vim_mode are set");
       }
     }
   }


### PR DESCRIPTION
In `Squirrel.custom.yaml`, we can use

```yaml
app_options/com.microsoft.VSCode:
  vim_mode: true
  ascii_mode: true
```

Add yaml support for PR https://github.com/rime/squirrel/pull/166 and solve issue https://github.com/rime/squirrel/issues/124. 

Since https://github.com/rime/squirrel/pull/166 has been pending for about 2 years, I made this little modification.
I think this can be solved by simply adding `vim_mode` option, and `ascii_mode` may be useless in this scenario.