### PR TITLE
Fix xargs warnings during make

### DIFF
--- a/package/add_data_files
+++ b/package/add_data_files
@@ -69,7 +69,7 @@ add_file() {
 }
 
 data_files=(
-    $(ls data/plum/* | xargs basename)
+    $(ls data/plum/* | xargs -n 1 basename)
 )
 
 for file in "${data_files[@]}"


### PR DESCRIPTION
I followed the [INSTALL.md](https://github.com/rime/squirrel/blob/master/INSTALL.md#build-squirrel) to build squirrel, and it failed.
```
$ make

bash package/add_data_files
basename: extra operand ‘data/plum/bopomofo_tw.schema.yaml’
Try 'basename --help' for more information.
make: *** [release] Error 1
```

I change `xargs` to `xargs -n 1` in package/add_data_files, and I build successfully. 