### PR TITLE
Explicitly support display P3 colorspace

### DIFF
--- a/SquirrelConfig.h
+++ b/SquirrelConfig.h
@@ -6,6 +6,7 @@ typedef NSMutableDictionary<NSString *, NSNumber *> SquirrelMutableAppOptions;
 @interface SquirrelConfig : NSObject
 
 @property(nonatomic, readonly) BOOL isOpen;
+@property(nonatomic) BOOL useP3;
 @property(nonatomic, readonly) NSString *schemaId;
 
 - (BOOL)openBaseConfig;

--- a/SquirrelConfig.m
+++ b/SquirrelConfig.m
@@ -15,6 +15,7 @@
   if (self) {
     _cache = [[NSMutableDictionary alloc] init];
   }
+  self.useP3 = false;
   return self;
 }
 
@@ -129,7 +130,7 @@
   if (cachedValue) {
     return cachedValue;
   }
-  NSColor *color = [[self class] colorFromString:[self getString:option]];
+  NSColor *color = [[self class] colorFromString:[self getString:option] inDisplayP3:_useP3];
   if (color) {
     _cache[option] = color;
     return color;
@@ -161,7 +162,7 @@
   return nil;
 }
 
-+ (NSColor *)colorFromString:(NSString *)string {
++ (NSColor *)colorFromString:(NSString *)string inDisplayP3:(BOOL)isP3 {
   if (string == nil) {
     return nil;
   }
@@ -174,11 +175,17 @@
     // 0xccbbaa
     sscanf(string.UTF8String, "0x%02x%02x%02x", &b, &g, &r);
   }
-
-  return [NSColor colorWithDeviceRed:(CGFloat)r / 255.
+  if (isP3) {
+    return [NSColor colorWithDisplayP3Red:(CGFloat)r / 255.
+                                    green:(CGFloat)g / 255.
+                                     blue:(CGFloat)b / 255.
+                                    alpha:(CGFloat)a / 255.];
+  } else {
+    return [NSColor colorWithSRGBRed:(CGFloat)r / 255.
                                green:(CGFloat)g / 255.
                                 blue:(CGFloat)b / 255.
                                alpha:(CGFloat)a / 255.];
+  }
 }
 
 @end

--- a/SquirrelPanel.m
+++ b/SquirrelPanel.m
@@ -1230,6 +1230,9 @@ static void updateTextOrientation(BOOL *isVerticalText, SquirrelConfig *config, 
   NSString *colorScheme = [config getString:@"style/color_scheme"];
   if (colorScheme) {
     NSString *prefix = [@"preset_color_schemes/" stringByAppendingString:colorScheme];
+    if (@available(macOS 10.12, *)) {
+      config.useP3 = [config getBool:[prefix stringByAppendingString:@"/in_display_p3"]];
+    }
     backgroundColor = [config getColor:[prefix stringByAppendingString:@"/back_color"]];
     borderColor = [config getColor:[prefix stringByAppendingString:@"/border_color"]];
     preeditBackgroundColor = [config getColor:[prefix stringByAppendingString:@"/preedit_back_color"]];


### PR DESCRIPTION
`colorWithDevice` will not guarantee same color across devices, use `style/color_scheme/in_display_p3` to explicitly specify this colorspace, otherwise use sRGB colorspace to interpret color codes.