### PR TITLE
fix: avoid implicit lossy integer transform

### DIFF
--- a/input_source.m
+++ b/input_source.m
@@ -19,7 +19,7 @@ void RegisterInputSource() {
 
 void ActivateInputSource() {
   CFArrayRef sourceList = TISCreateInputSourceList(NULL, true);
-  for (int i = 0; i < CFArrayGetCount(sourceList); ++i) {
+  for (CFIndex i = 0; i < CFArrayGetCount(sourceList); ++i) {
     TISInputSourceRef inputSource = (TISInputSourceRef)(CFArrayGetValueAtIndex(
         sourceList, i));
     NSString *sourceID = (__bridge NSString *)(TISGetInputSourceProperty(
@@ -42,7 +42,7 @@ void ActivateInputSource() {
 
 void DeactivateInputSource() {
   CFArrayRef sourceList = TISCreateInputSourceList(NULL, true);
-  for (int i = CFArrayGetCount(sourceList); i > 0; --i) {
+  for (CFIndex i = CFArrayGetCount(sourceList); i > 0; --i) {
     TISInputSourceRef inputSource = (TISInputSourceRef)(CFArrayGetValueAtIndex(
         sourceList, i - 1));
     NSString *sourceID = (__bridge NSString *)(TISGetInputSourceProperty(
@@ -60,7 +60,7 @@ void DeactivateInputSource() {
 BOOL IsInputSourceActive() {
   int active = 0;
   CFArrayRef sourceList = TISCreateInputSourceList(NULL, true);
-  for (int i = 0; i < CFArrayGetCount(sourceList); ++i) {
+  for (CFIndex i = 0; i < CFArrayGetCount(sourceList); ++i) {
     TISInputSourceRef inputSource = (TISInputSourceRef)(CFArrayGetValueAtIndex(
         sourceList, i));
     NSString *sourceID = (__bridge NSString *)(TISGetInputSourceProperty(


### PR DESCRIPTION
Fixes warnings from `-Wshorten-64-to-32`:

https://travis-ci.org/github/rime/squirrel/builds/758070376#L1120