### PR TITLE
fix: default comment font size to fontSize

### DIFF
--- a/SquirrelPanel.m
+++ b/SquirrelPanel.m
@@ -1473,6 +1473,9 @@ static void updateTextOrientation(BOOL *isVerticalText, SquirrelConfig *config, 
   if (labelFontSize == 0) {
     labelFontSize = fontSize;
   }
+  if (commentFontSize == 0) {
+    commentFontSize = fontSize;
+  }
   NSFontDescriptor *fontDescriptor = nil;
   NSFont *font = nil;
   if (fontName != nil) {


### PR DESCRIPTION
A follow-up to #511 which addresses https://github.com/rime/squirrel/pull/511#issuecomment-775299704.

Thanks to @LEOYoon-Tsaw for bug reports.