### PR TITLE
Optimize line-breaking bahavior

### DIFF
--- a/SquirrelPanel.m
+++ b/SquirrelPanel.m
@@ -234,7 +234,6 @@ SquirrelTheme *_darkTheme;
 - (NSRect)contentRect {
   NSRange glyphRange = [_text.layoutManagers[0] glyphRangeForTextContainer:_text.layoutManagers[0].textContainers[0]];
   NSRect rect = [_text.layoutManagers[0] boundingRectForGlyphRange:glyphRange inTextContainer:_text.layoutManagers[0].textContainers[0]];
-  CGFloat frameWidth = self.textFrameWidth;
   __block long actualWidth = 0;
   [_text.layoutManagers[0] enumerateLineFragmentsForGlyphRange:glyphRange usingBlock:^(CGRect rect, CGRect usedRect, NSTextContainer *textContainer, NSRange glyphRange, BOOL *stop) {
     if (usedRect.size.width > actualWidth) {
@@ -242,8 +241,6 @@ SquirrelTheme *_darkTheme;
     }
   }];
   rect.size.width = actualWidth;
-  rect.origin.x -= frameWidth;
-  rect.size.width += frameWidth * 2;
   return rect;
 }
 

--- a/SquirrelPanel.m
+++ b/SquirrelPanel.m
@@ -6,7 +6,7 @@ static const CGFloat kOffsetHeight = 5;
 static const CGFloat kDefaultFontSize = 24;
 static const CGFloat kBlendedBackgroundColorFraction = 1.0 / 5;
 static const NSTimeInterval kShowStatusDuration = 1.2;
-static NSString *const kDefaultCandidateFormat = @"%c. %@";
+static NSString *const kDefaultCandidateFormat = @"%c.\u00A0%@";
 
 @interface SquirrelTheme : NSObject
 

--- a/SquirrelPanel.m
+++ b/SquirrelPanel.m
@@ -240,6 +240,13 @@ SquirrelTheme *_darkTheme;
   NSRange glyphRange = [_text.layoutManagers[0] glyphRangeForTextContainer:_text.layoutManagers[0].textContainers[0]];
   NSRect rect = [_text.layoutManagers[0] boundingRectForGlyphRange:glyphRange inTextContainer:_text.layoutManagers[0].textContainers[0]];
   CGFloat frameWidth = self.textFrameWidth;
+  __block long actualWidth = 0;
+  [_text.layoutManagers[0] enumerateLineFragmentsForGlyphRange:glyphRange usingBlock:^(CGRect rect, CGRect usedRect, NSTextContainer *textContainer, NSRange glyphRange, BOOL *stop) {
+    if (usedRect.size.width > actualWidth) {
+      actualWidth = usedRect.size.width;
+    }
+  }];
+  rect.size.width = actualWidth;
   rect.origin.x -= frameWidth;
   rect.size.width += frameWidth * 2;
   return rect;

--- a/SquirrelPanel.m
+++ b/SquirrelPanel.m
@@ -738,9 +738,9 @@ void convertToVerticalGlyph(NSMutableAttributedString *originalText, NSRange str
   const NSSize hangulSize = [hangulChar boundingRectWithSize:NSZeroSize options:0].size;
   stringRange = [originalText.string rangeOfComposedCharacterSequencesForRange:stringRange];
   NSUInteger i = stringRange.location;
-  while (i < stringRange.location+stringRange.length) {
+  while (i < NSMaxRange(stringRange)) {
     NSRange range = [originalText.string rangeOfComposedCharacterSequenceAtIndex:i];
-    i = range.location + range.length;
+    i = NSMaxRange(range);
     NSRect charRect = [[originalText attributedSubstringFromRange:range] boundingRectWithSize:NSZeroSize options:0];
     // Also adjust the baseline so upright and lying charcters are properly aligned
     if ((charRect.size.width >= cjkRect.size.width) || (charRect.size.width >= hangulSize.width)) {
@@ -767,6 +767,20 @@ void changeEmojiSize(NSMutableAttributedString *text, CGFloat emojiFontSize) {
     }
     i = currentFontRange.location + currentFontRange.length;
   }
+}
+
+NSAttributedString *insert(NSString *separator, NSAttributedString *betweenText) {
+  NSRange range = [betweenText.string rangeOfComposedCharacterSequenceAtIndex:0];
+  NSAttributedString *attributedSeperator = [[NSAttributedString alloc] initWithString:separator attributes:[betweenText attributesAtIndex:0 effectiveRange:nil]];
+  NSUInteger i = NSMaxRange(range);
+  NSMutableAttributedString *workingString = [[betweenText attributedSubstringFromRange:range] mutableCopy];
+  while (i < betweenText.length) {
+    range = [betweenText.string rangeOfComposedCharacterSequenceAtIndex:i];
+    [workingString appendAttributedString:attributedSeperator];
+    [workingString appendAttributedString:[betweenText attributedSubstringFromRange:range]];
+    i = NSMaxRange(range);
+  }
+  return workingString;
 }
 
 + (NSColor *)secondaryTextColor {
@@ -863,6 +877,15 @@ void changeEmojiSize(NSMutableAttributedString *text, CGFloat emojiFontSize) {
   }
 }
 
+- (CGFloat)getMaxTextWidth:(SquirrelTheme *)theme {
+  NSFont *currentFont = theme.attrs[NSFontAttributeName];
+  CGFloat fontScale = currentFont.pointSize / 12;
+  CGFloat textWidthRatio = MIN(1.0, 1.0 / (theme.vertical ? 4 : 3) + fontScale / 12);
+  return theme.vertical
+    ? NSHeight(_screenRect) * textWidthRatio - theme.edgeInset.height * 2
+    : NSWidth(_screenRect) * textWidthRatio - theme.edgeInset.width * 2;
+}
+
 // Get the window size, the windows will be the dirtyRect in SquirrelView.drawRect
 - (void)show {
   [self getCurrentScreen];
@@ -876,13 +899,9 @@ void changeEmojiSize(NSMutableAttributedString *text, CGFloat emojiFontSize) {
   }
 
   //Break line if the text is too long, based on screen size.
-  CGFloat textWidth = _view.text.size.width + _view.textFrameWidth * 2;
-  NSFont *currentFont = theme.attrs[NSFontAttributeName];
-  CGFloat fontScale = currentFont.pointSize / 12;
-  CGFloat textWidthRatio = MIN(1.0, 1.0 / (theme.vertical ? 4 : 3) + fontScale / 12);
-  CGFloat maxTextWidth = theme.vertical
-  ? NSHeight(_screenRect) * textWidthRatio - theme.edgeInset.height * 2
-  : NSWidth(_screenRect) * textWidthRatio - theme.edgeInset.width * 2;
+
+  CGFloat textWidth = _view.text.size.width;
+  CGFloat maxTextWidth = [self getMaxTextWidth:theme];
   if (textWidth > maxTextWidth) {
     textWidth = maxTextWidth;
   }
@@ -992,6 +1011,7 @@ void changeEmojiSize(NSMutableAttributedString *text, CGFloat emojiFontSize) {
   }
 
   SquirrelTheme *theme = _view.currentTheme;
+  CGFloat maxTextWidth = [self getMaxTextWidth:theme];
 
   NSMutableAttributedString *text = [[NSMutableAttributedString alloc] init];
   NSUInteger candidateStartPos = 0;
@@ -1085,9 +1105,17 @@ void changeEmojiSize(NSMutableAttributedString *text, CGFloat emojiFontSize) {
 
     NSUInteger candidateStart = line.length;
     NSString *candidate = candidates[i];
-    [line appendAttributedString:[[NSAttributedString alloc]
-                                     initWithString:candidate.precomposedStringWithCanonicalMapping
-                                         attributes:attrs]];
+    NSAttributedString *candidateAttributedString = [[NSAttributedString alloc]
+                                                     initWithString:candidate.precomposedStringWithCanonicalMapping
+                                                     attributes:attrs];
+    CGFloat candidateWidth = [candidateAttributedString boundingRectWithSize:NSZeroSize options:NSStringDrawingUsesLineFragmentOrigin].size.width;
+    if (candidateWidth <= maxTextWidth * 0.2) {
+      // Unicode Word Joiner
+      candidateAttributedString = insert(@"\u2060", candidateAttributedString);
+    }
+    
+    [line appendAttributedString:candidateAttributedString];
+    
     // Use left-to-right marks to prevent right-to-left text from changing the
     // layout of non-candidate text.
     [line addAttribute:NSWritingDirectionAttributeName value:@[@0] range:NSMakeRange(candidateStart, line.length-candidateStart)];
@@ -1121,13 +1149,28 @@ void changeEmojiSize(NSMutableAttributedString *text, CGFloat emojiFontSize) {
 
     if (i < comments.count && [comments[i] length] != 0) {
       NSUInteger commentStart = line.length;
-      [line appendAttributedString:[[NSAttributedString alloc]
-                                       initWithString:@" "
-                                           attributes:commentAttrs]];
+      CGFloat candidateAndLabelWidth = [line boundingRectWithSize:NSZeroSize options:NSStringDrawingUsesLineFragmentOrigin].size.width;
       NSString *comment = comments[i];
+      NSAttributedString *commentAttributedString = [[NSAttributedString alloc]
+                                                     initWithString:comment.precomposedStringWithCanonicalMapping
+                                                     attributes:commentAttrs];
+      CGFloat commentWidth = [commentAttributedString boundingRectWithSize:NSZeroSize options:NSStringDrawingUsesLineFragmentOrigin].size.width;
+      if (commentWidth <= maxTextWidth * 0.2) {
+        // Unicode Word Joiner
+        commentAttributedString = insert(@"\u2060", commentAttributedString);
+      }
+      
+      NSString *commentSeparator;
+      if (candidateAndLabelWidth + commentWidth <= maxTextWidth * 0.3) {
+        // Non-Breaking White Space
+        commentSeparator = @"\u00A0";
+      } else {
+        commentSeparator = @" ";
+      }
       [line appendAttributedString:[[NSAttributedString alloc]
-                                       initWithString:comment.precomposedStringWithCanonicalMapping
+                                       initWithString:commentSeparator
                                            attributes:commentAttrs]];
+      [line appendAttributedString:commentAttributedString];
       if (theme.vertical) {
         convertToVerticalGlyph(line, NSMakeRange(commentStart, line.length-commentStart));
       }

--- a/data/squirrel.yaml
+++ b/data/squirrel.yaml
@@ -34,7 +34,7 @@ style:
   # space between preedit and candidates in non-inline mode
   spacing: 10
 
-  #candidate_format: '%c.\u002A%@'
+  #candidate_format: '%c.\u00A0%@'
 
   # adjust the base line of vertical text
   #base_offset: 6

--- a/data/squirrel.yaml
+++ b/data/squirrel.yaml
@@ -34,7 +34,7 @@ style:
   # space between preedit and candidates in non-inline mode
   spacing: 10
 
-  #candidate_format: '%c. %@'
+  #candidate_format: '%c.\u002A%@'
 
   # adjust the base line of vertical text
   #base_offset: 6


### PR DESCRIPTION
Use U+2060 Word Joiner and U+A0 Non-Breaking White Space to adjust line breaking behavior.

If pure Candidate width is not exceeding 20% of maximum width, insert U+2060 between characters in Candidate.

If Comment width is not exceeding 20% of maximum width, insert U+2060 between characters in Comment.

If Label + Candidate + Comment width is not exceeding 30% of maximum width, use U+A0 instead of U+20 to separate between candidate and comment.

Address #515 

Note, the linebreaking behavior between label and candidate, or in preedit is not addressed in this pull, user can customize using the 2 afore mentioned unicode symbols in configuration files already.