### PR TITLE
Add `inlineCandidate` option

### DIFF
--- a/SquirrelInputController.m
+++ b/SquirrelInputController.m
@@ -523,14 +523,14 @@ const int N_KEY_ROLL_OVER = 50;
         if ((caretPos >= NSMaxRange(selRange)) && (caretPos < preeditText.length)) {
           condidatePreviewText = [condidatePreviewText stringByAppendingString:[preeditText substringWithRange:NSMakeRange(caretPos, preeditText.length-caretPos)]];
         }
-        [self showPreeditString:condidatePreviewText selRange:NSMakeRange(selRange.location, condidatePreviewText.length-selRange.location) caretPos:caretPos > selRange.location ? selRange.location : selRange.location];
+        [self showPreeditString:condidatePreviewText selRange:NSMakeRange(selRange.location, condidatePreviewText.length-selRange.location) caretPos:condidatePreviewText.length-(preeditText.length-caretPos)];
       } else {
         if ((NSMaxRange(selRange) < caretPos) && (caretPos > selRange.location)) {
           condidatePreviewText = [condidatePreviewText substringWithRange:NSMakeRange(0, condidatePreviewText.length-(caretPos-NSMaxRange(selRange)))];
         } else if ((NSMaxRange(selRange) < preeditText.length) && (caretPos <= selRange.location)) {
           condidatePreviewText = [condidatePreviewText substringWithRange:NSMakeRange(0, condidatePreviewText.length-(preeditText.length-NSMaxRange(selRange)))];
         }
-        [self showPreeditString:condidatePreviewText selRange:NSMakeRange(selRange.location, condidatePreviewText.length-selRange.location) caretPos:caretPos > selRange.location ? selRange.location : selRange.location-1];
+        [self showPreeditString:condidatePreviewText selRange:NSMakeRange(selRange.location, condidatePreviewText.length-selRange.location) caretPos:condidatePreviewText.length];
       }
     } else {
       if (_inlinePreedit) {

--- a/SquirrelPanel.h
+++ b/SquirrelPanel.h
@@ -10,6 +10,8 @@
 @property(nonatomic, readonly) BOOL vertical;
 // Show preedit text inline.
 @property(nonatomic, readonly) BOOL inlinePreedit;
+// Show first candidate inline
+@property(nonatomic, readonly) BOOL inlineCandidate;
 
 // position of input caret on screen.
 @property(nonatomic, assign) NSRect position;

--- a/SquirrelPanel.m
+++ b/SquirrelPanel.m
@@ -28,6 +28,7 @@ static NSString *const kDefaultCandidateFormat = @"%c. %@";
 @property(nonatomic, readonly) BOOL linear;
 @property(nonatomic, readonly) BOOL vertical;
 @property(nonatomic, readonly) BOOL inlinePreedit;
+@property(nonatomic, readonly) BOOL inlineCandidate;
 
 @property(nonatomic, strong, readonly) NSDictionary *attrs;
 @property(nonatomic, strong, readonly) NSDictionary *highlightedAttrs;
@@ -59,7 +60,8 @@ static NSString *const kDefaultCandidateFormat = @"%c. %@";
                   alpha:(CGFloat)alpha
                  linear:(BOOL)linear
                vertical:(BOOL)vertical
-          inlinePreedit:(BOOL)inlinePreedit;
+          inlinePreedit:(BOOL)inlinePreedit
+        inlineCandidate:(BOOL)inlineCandidate;
 
 - (void)       setAttrs:(NSMutableDictionary *)attrs
              labelAttrs:(NSMutableDictionary *)labelAttrs
@@ -124,7 +126,8 @@ preeditHighlightedAttrs:(NSMutableDictionary *)preeditHighlightedAttrs;
                   alpha:(CGFloat)alpha
                  linear:(BOOL)linear
                vertical:(BOOL)vertical
-          inlinePreedit:(BOOL)inlinePreedit {
+          inlinePreedit:(BOOL)inlinePreedit
+        inlineCandidate:(BOOL)inlineCandidate {
   _cornerRadius = cornerRadius;
   _hilitedCornerRadius = hilitedCornerRadius;
   _edgeInset = edgeInset;
@@ -135,6 +138,7 @@ preeditHighlightedAttrs:(NSMutableDictionary *)preeditHighlightedAttrs;
   _linear = linear;
   _vertical = vertical;
   _inlinePreedit = inlinePreedit;
+  _inlineCandidate = inlineCandidate;
 }
 
 - (void)       setAttrs:(NSMutableDictionary *)attrs
@@ -719,6 +723,10 @@ void expand(NSMutableArray<NSValue *> *vertex, NSRect innerBorder, NSRect outerB
   return _view.currentTheme.inlinePreedit;
 }
 
+- (BOOL)inlineCandidate {
+  return _view.currentTheme.inlineCandidate;
+}
+
 CGFloat minimumHeight(NSDictionary *attribute) {
   const NSAttributedString *spaceChar = [[NSAttributedString alloc] initWithString:@" " attributes:attribute];
   const CGFloat minimumHeight = [spaceChar boundingRectWithSize:NSZeroSize options:0].size.height;
@@ -1283,6 +1291,7 @@ static void updateTextOrientation(BOOL *isVerticalText, SquirrelConfig *config, 
   updateCandidateListLayout(&linear, config, @"style");
   updateTextOrientation(&vertical, config, @"style");
   BOOL inlinePreedit = [config getBool:@"style/inline_preedit"];
+  BOOL inlineCandidate = [config getBool:@"style/inline_candidate"];
   NSString *candidateFormat = [config getString:@"style/candidate_format"];
 
   NSString *fontName = [config getString:@"style/font_face"];
@@ -1370,6 +1379,11 @@ static void updateTextOrientation(BOOL *isVerticalText, SquirrelConfig *config, 
         [config getOptionalBool:[prefix stringByAppendingString:@"/inline_preedit"]];
     if (inlinePreeditOverridden) {
       inlinePreedit = inlinePreeditOverridden.boolValue;
+    }
+    NSNumber *inlineCandidateOverridden =
+        [config getOptionalBool:[prefix stringByAppendingString:@"/inline_candidate"]];
+    if (inlineCandidateOverridden) {
+      inlineCandidate = inlineCandidateOverridden.boolValue;
     }
     NSString *candidateFormatOverridden =
         [config getString:[prefix stringByAppendingString:@"/candidate_format"]];
@@ -1616,7 +1630,8 @@ static void updateTextOrientation(BOOL *isVerticalText, SquirrelConfig *config, 
                    alpha:(alpha == 0 ? 1.0 : alpha)
                   linear:linear
                 vertical:vertical
-           inlinePreedit:inlinePreedit];
+           inlinePreedit:inlinePreedit
+        inlineCandidate:inlineCandidate];
 
   theme.native = isNative;
   theme.candidateFormat = (candidateFormat ? candidateFormat : kDefaultCandidateFormat);


### PR DESCRIPTION
(cherry picked from commit e75aec1478fe9f9faafbc9d0062b55d5504abd62)

`style/inline_candidate` is a parallel option to `style/inline_preedit`. Four combinations are summarized as:

| | inline_candidate=true| inline_candidate=false|
|:---:|:---:|:---:|
| **inline_preedit=true** |Both selected candidate and unselected preedit are inline|No candidate inline, only preedit|
| **inline_preedit=false** |Only selected candidate inline, no unselected preedit|Blank space|

Preview:

<img width="759" alt="Screen_Shot 2021-08-01 at 17 31 18 (2)" src="https://user-images.githubusercontent.com/4469383/127785987-5e2774d8-2f14-44b2-9060-9d467fb505b1.png">

<img width="754" alt="Screen_Shot 2021-08-01 at 17 31 56 (2)" src="https://user-images.githubusercontent.com/4469383/127785988-9b87735f-e307-432e-9b00-6c83fe8cae1b.png">
