### PR TITLE
Replace Bintray badge to GitHub releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 【鼠鬚管】輸入法
 ===
-[![Download](https://api.bintray.com/packages/rime/squirrel/release/images/download.svg)](https://bintray.com/rime/squirrel/release/_latestVersion)
+[![Download](https://img.shields.io/github/v/release/rime/squirrel)](https://github.com/rime/squirrel/releases/latest)
 [![Build Status](https://travis-ci.org/rime/squirrel.svg)](https://travis-ci.org/rime/squirrel)
 [![GitHub Tag](https://img.shields.io/github/tag/rime/squirrel.svg)](https://github.com/rime/squirrel)
 


### PR DESCRIPTION
Bintray has been shutdown, see https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/.