### PR TITLE
允许以 defaults write 覆写指定的系统键盘布局

### DIFF
--- a/3rdParty/vChewingProject/CocoaExtension4RIME/CocoaExtension_Misc.swift
+++ b/3rdParty/vChewingProject/CocoaExtension4RIME/CocoaExtension_Misc.swift
@@ -1,0 +1,71 @@
+// (c) 2021 and onwards The vChewing Project (MIT-NTL License).
+// ====================
+// This code is released under the MIT license (SPDX-License-Identifier: MIT)
+// ... with NTL restriction stating that:
+// No trademark license is granted to use the trade names, trademarks, service
+// marks, or product names of Contributor, except as required to fulfill notice
+// requirements defined in MIT License.
+
+// 注：該檔案的內容針對 RIME SQUIRREL 的開發需求做過調整，與威注音輸入法倉庫內建的檔案有所不同。
+
+import Cocoa
+
+// MARK: NSRect Extension
+
+public extension NSRect {
+  static var seniorTheBeast: NSRect {
+    NSRect(x: 0.0, y: 0.0, width: 0.114, height: 0.514)
+  }
+}
+
+public extension NSApplication {
+  // MARK: - System Dark Mode Status Detector.
+
+  static var isDarkMode: Bool {
+    if #unavailable(macOS 10.14) { return false }
+    if #available(macOS 10.15, *) {
+      let appearanceDescription = NSApplication.shared.effectiveAppearance.debugDescription
+        .lowercased()
+      return appearanceDescription.contains("dark")
+    } else if let appleInterfaceStyle = UserDefaults.standard.string(forKey: "AppleInterfaceStyle") {
+      return appleInterfaceStyle.lowercased().contains("dark")
+    }
+    return false
+  }
+
+  // MARK: - Tell whether this IME is running with Root privileges.
+
+  static var isSudoMode: Bool {
+    NSUserName() == "root"
+  }
+}
+
+// MARK: - Real Home Dir for Sandboxed Apps
+
+public extension FileManager {
+  /// 如果輸入法有做過 Sandbox 處理的話，那麼這個命令會派上用場。
+  static let realHomeDir = URL(
+    fileURLWithFileSystemRepresentation: getpwuid(getuid()).pointee.pw_dir, isDirectory: true, relativeTo: nil
+  )
+}
+
+// MARK: - Trash a file if it exists.
+
+public extension FileManager {
+  @discardableResult static func trashTargetIfExists(_ path: String) -> Bool {
+    do {
+      if FileManager.default.fileExists(atPath: path) {
+        // 塞入垃圾桶
+        try FileManager.default.trashItem(
+          at: URL(fileURLWithPath: path), resultingItemURL: nil
+        )
+      } else {
+        NSLog("Item doesn't exist: \(path)")
+      }
+    } catch let error as NSError {
+      NSLog("Failed from removing this object: \(path) || Error: \(error)")
+      return false
+    }
+    return true
+  }
+}

--- a/3rdParty/vChewingProject/CocoaExtension4RIME/CocoaExtension_Misc.swift
+++ b/3rdParty/vChewingProject/CocoaExtension4RIME/CocoaExtension_Misc.swift
@@ -22,7 +22,7 @@ public extension NSApplication {
   // MARK: - System Dark Mode Status Detector.
 
   static var isDarkMode: Bool {
-    if #unavailable(macOS 10.14) { return false }
+    if #available(macOS 10.14, *) {} else { return false }
     if #available(macOS 10.15, *) {
       let appearanceDescription = NSApplication.shared.effectiveAppearance.debugDescription
         .lowercased()

--- a/3rdParty/vChewingProject/CocoaExtension4RIME/CocoaExtension_NSEvent.swift
+++ b/3rdParty/vChewingProject/CocoaExtension4RIME/CocoaExtension_NSEvent.swift
@@ -1,0 +1,308 @@
+// (c) 2022 and onwards The vChewing Project (MIT-NTL License).
+// ====================
+// This code is released under the MIT license (SPDX-License-Identifier: MIT)
+// ... with NTL restriction stating that:
+// No trademark license is granted to use the trade names, trademarks, service
+// marks, or product names of Contributor, except as required to fulfill notice
+// requirements defined in MIT License.
+
+// 注：該檔案的內容與威注音輸入法倉庫內建的檔案可能有所不同。
+// 本文當中提到的 SymbolMenoKey 是指波浪鍵。
+// 但因為 JIS 鍵盤沒有波浪鍵，所以屆時對應的生效按鍵是 JIS 鍵盤獨有的下斜槓鍵。
+
+import Cocoa
+
+// MARK: - NSEvent Extension - Reconstructors
+
+public extension NSEvent {
+  func reinitiate(
+    with type: NSEvent.EventType? = nil,
+    location: NSPoint? = nil,
+    modifierFlags: NSEvent.ModifierFlags? = nil,
+    timestamp: TimeInterval? = nil,
+    windowNumber: Int? = nil,
+    characters: String? = nil,
+    charactersIgnoringModifiers: String? = nil,
+    isARepeat: Bool? = nil,
+    keyCode: UInt16? = nil
+  ) -> NSEvent? {
+    let oldChars: String = {
+      if self.type == .flagsChanged { return "" }
+      return self.characters ?? ""
+    }()
+    return NSEvent.keyEvent(
+      with: type ?? self.type,
+      location: location ?? locationInWindow,
+      modifierFlags: modifierFlags ?? self.modifierFlags,
+      timestamp: timestamp ?? self.timestamp,
+      windowNumber: windowNumber ?? self.windowNumber,
+      context: nil,
+      characters: characters ?? oldChars,
+      charactersIgnoringModifiers: charactersIgnoringModifiers ?? characters ?? oldChars,
+      isARepeat: isARepeat ?? self.isARepeat,
+      keyCode: keyCode ?? self.keyCode
+    )
+  }
+
+  /// 自 Emacs 熱鍵的 NSEvent 翻譯回標準 NSEvent。失敗的話則會返回原始 NSEvent 自身。
+  /// - Parameter isVerticalTyping: 是否按照縱排來操作。
+  /// - Returns: 翻譯結果。失敗的話則返回翻譯原文。
+  func convertFromEmacKeyEvent(isVerticalContext: Bool) -> NSEvent {
+    guard isEmacsKey else { return self }
+    let newKeyCode: UInt16 = {
+      switch isVerticalContext {
+      case false: return EmacsKey.charKeyMapHorizontal[charCode] ?? 0
+      case true: return EmacsKey.charKeyMapVertical[charCode] ?? 0
+      }
+    }()
+    guard newKeyCode != 0 else { return self }
+    let newCharScalar: Unicode.Scalar = {
+      switch charCode {
+      case 6:
+        return isVerticalContext
+          ? NSEvent.SpecialKey.downArrow.unicodeScalar : NSEvent.SpecialKey.rightArrow.unicodeScalar
+      case 2:
+        return isVerticalContext
+          ? NSEvent.SpecialKey.upArrow.unicodeScalar : NSEvent.SpecialKey.leftArrow.unicodeScalar
+      case 1: return NSEvent.SpecialKey.home.unicodeScalar
+      case 5: return NSEvent.SpecialKey.end.unicodeScalar
+      case 4: return NSEvent.SpecialKey.deleteForward.unicodeScalar // Use "deleteForward" for PC delete.
+      case 22: return NSEvent.SpecialKey.pageDown.unicodeScalar
+      default: return .init(0)
+      }
+    }()
+    let newChar = String(newCharScalar)
+    return reinitiate(modifierFlags: [], characters: newChar, charactersIgnoringModifiers: newChar, keyCode: newKeyCode)
+      ?? self
+  }
+}
+
+// MARK: - NSEvent Extension - InputSignalProtocol
+
+public extension NSEvent {
+  var isTypingVertical: Bool { charactersIgnoringModifiers == "Vertical" }
+  var text: String { convertedFromPhonabets() }
+  var inputTextIgnoringModifiers: String? {
+    guard charactersIgnoringModifiers != nil else { return nil }
+    return convertedFromPhonabets(ignoringModifiers: true)
+  }
+
+  var charCode: UInt16 {
+    guard type != .flagsChanged else { return 0 }
+    guard characters != nil else { return 0 }
+    // 這裡不用「count > 0」，因為該整數變數只要「!isEmpty」那就必定滿足這個條件。
+    guard !text.isEmpty else { return 0 }
+    let scalars = text.unicodeScalars
+    let result = scalars[scalars.startIndex].value
+    return result <= UInt16.max ? UInt16(result) : UInt16.max
+  }
+
+  var isFlagChanged: Bool { type == .flagsChanged }
+
+  var isEmacsKey: Bool {
+    // 這裡不能只用 isControlHold，因為這裡對修飾鍵的要求有排他性。
+    [6, 2, 1, 5, 4, 22].contains(charCode) && modifierFlags == .control
+  }
+
+  // 摁 Alt+Shift+主鍵盤區域數字鍵 的話，根據不同的 macOS 鍵盤佈局種類，會出現不同的符號結果。
+  // 然而呢，KeyCode 卻是一致的。於是這裡直接準備一個換算表來用。
+  // 這句用來返回換算結果。
+  var mainAreaNumKeyChar: String? { mapMainAreaNumKey[keyCode] }
+
+  // 除了 ANSI charCode 以外，其餘一律過濾掉，免得純 Swift 版 KeyHandler 被餵屎。
+  var isInvalid: Bool {
+    (0x20 ... 0xFF).contains(charCode) ? false : !(isReservedKey && !isKeyCodeBlacklisted)
+  }
+
+  var isKeyCodeBlacklisted: Bool {
+    guard let code = KeyCodeBlackListed(rawValue: keyCode) else { return false }
+    return code.rawValue != KeyCode.kNone.rawValue
+  }
+
+  var isReservedKey: Bool {
+    guard let code = KeyCode(rawValue: keyCode) else { return false }
+    return code.rawValue != KeyCode.kNone.rawValue
+  }
+
+  /// 單獨用 flags 來判定數字小鍵盤輸入的方法已經失效了，所以必須再增補用 KeyCode 判定的方法。
+  var isNumericPadKey: Bool { arrNumpadKeyCodes.contains(keyCode) }
+  var isMainAreaNumKey: Bool { arrMainAreaNumKey.contains(keyCode) }
+  var isShiftHold: Bool { modifierFlags.contains([.shift]) }
+  var isCommandHold: Bool { modifierFlags.contains([.command]) }
+  var isControlHold: Bool { modifierFlags.contains([.control]) }
+  var isControlHotKey: Bool { modifierFlags.contains([.control]) && text.first?.isLetter ?? false }
+  var isOptionHold: Bool { modifierFlags.contains([.option]) }
+  var isOptionHotKey: Bool { modifierFlags.contains([.option]) && text.first?.isLetter ?? false }
+  var isCapsLockOn: Bool { modifierFlags.contains([.capsLock]) }
+  var isFunctionKeyHold: Bool { modifierFlags.contains([.function]) }
+  var isNonLaptopFunctionKey: Bool { modifierFlags.contains([.numericPad]) && !isNumericPadKey }
+  var isEnter: Bool { [KeyCode.kCarriageReturn, KeyCode.kLineFeed].contains(KeyCode(rawValue: keyCode)) }
+  var isTab: Bool { KeyCode(rawValue: keyCode) == KeyCode.kTab }
+  var isUp: Bool { KeyCode(rawValue: keyCode) == KeyCode.kUpArrow }
+  var isDown: Bool { KeyCode(rawValue: keyCode) == KeyCode.kDownArrow }
+  var isLeft: Bool { KeyCode(rawValue: keyCode) == KeyCode.kLeftArrow }
+  var isRight: Bool { KeyCode(rawValue: keyCode) == KeyCode.kRightArrow }
+  var isPageUp: Bool { KeyCode(rawValue: keyCode) == KeyCode.kPageUp }
+  var isPageDown: Bool { KeyCode(rawValue: keyCode) == KeyCode.kPageDown }
+  var isSpace: Bool { KeyCode(rawValue: keyCode) == KeyCode.kSpace }
+  var isBackSpace: Bool { KeyCode(rawValue: keyCode) == KeyCode.kBackSpace }
+  var isEsc: Bool { KeyCode(rawValue: keyCode) == KeyCode.kEscape }
+  var isHome: Bool { KeyCode(rawValue: keyCode) == KeyCode.kHome }
+  var isEnd: Bool { KeyCode(rawValue: keyCode) == KeyCode.kEnd }
+  var isDelete: Bool { KeyCode(rawValue: keyCode) == KeyCode.kWindowsDelete }
+
+  var isCursorBackward: Bool {
+    isTypingVertical
+      ? KeyCode(rawValue: keyCode) == .kUpArrow
+      : KeyCode(rawValue: keyCode) == .kLeftArrow
+  }
+
+  var isCursorForward: Bool {
+    isTypingVertical
+      ? KeyCode(rawValue: keyCode) == .kDownArrow
+      : KeyCode(rawValue: keyCode) == .kRightArrow
+  }
+
+  var isCursorClockRight: Bool {
+    isTypingVertical
+      ? KeyCode(rawValue: keyCode) == .kRightArrow
+      : KeyCode(rawValue: keyCode) == .kUpArrow
+  }
+
+  var isCursorClockLeft: Bool {
+    isTypingVertical
+      ? KeyCode(rawValue: keyCode) == .kLeftArrow
+      : KeyCode(rawValue: keyCode) == .kDownArrow
+  }
+
+  var isASCII: Bool { charCode < 0x80 }
+
+  // 這裡必須加上「flags == .shift」，否則會出現某些情況下輸入法「誤判當前鍵入的非 Shift 字符為大寫」的問題
+  var isUpperCaseASCIILetterKey: Bool {
+    (65 ... 90).contains(charCode) && modifierFlags == .shift
+  }
+
+  // 這裡必須用 KeyCode，這樣才不會受隨 macOS 版本更動的 Apple 動態注音鍵盤排列內容的影響。
+  // 只是必須得與 ![input isShiftHold] 搭配使用才可以（也就是僅判定 Shift 沒被摁下的情形）。
+  var isSymbolMenuPhysicalKey: Bool {
+    [KeyCode.kSymbolMenuPhysicalKeyIntl, KeyCode.kSymbolMenuPhysicalKeyJIS].contains(KeyCode(rawValue: keyCode))
+  }
+}
+
+// MARK: - Enums of Constants
+
+// Use KeyCodes as much as possible since its recognition won't be affected by macOS Base Keyboard Layouts.
+// KeyCodes: https://eastmanreference.com/complete-list-of-applescript-key-codes
+// Also: HIToolbox.framework/Versions/A/Headers/Events.h
+public enum KeyCode: UInt16 {
+  case kNone = 0
+  case kCarriageReturn = 36 // Renamed from "kReturn" to avoid nomenclatural confusions.
+  case kTab = 48
+  case kSpace = 49
+  case kSymbolMenuPhysicalKeyIntl = 50 // vChewing Specific (Non-JIS)
+  case kBackSpace = 51 // Renamed from "kDelete" to avoid nomenclatural confusions.
+  case kEscape = 53
+  case kCommand = 55
+  case kShift = 56
+  case kCapsLock = 57
+  case kOption = 58
+  case kControl = 59
+  case kRightShift = 60
+  case kRightOption = 61
+  case kRightControl = 62
+  case kFunction = 63
+  case kF17 = 64
+  case kVolumeUp = 72
+  case kVolumeDown = 73
+  case kMute = 74
+  case kLineFeed = 76 // Another keyCode to identify the Enter Key, typable by Fn+Enter.
+  case kF18 = 79
+  case kF19 = 80
+  case kF20 = 90
+  case kSymbolMenuPhysicalKeyJIS = 94 // vChewing Specific (JIS)
+  case kF5 = 96
+  case kF6 = 97
+  case kF7 = 98
+  case kF3 = 99
+  case kF8 = 100
+  case kF9 = 101
+  case kF11 = 103
+  case kF13 = 105 // PrtSc
+  case kF16 = 106
+  case kF14 = 107
+  case kF10 = 109
+  case kF12 = 111
+  case kF15 = 113
+  case kHelp = 114 // Insert
+  case kHome = 115
+  case kPageUp = 116
+  case kWindowsDelete = 117 // Renamed from "kForwardDelete" to avoid nomenclatural confusions.
+  case kF4 = 118
+  case kEnd = 119
+  case kF2 = 120
+  case kPageDown = 121
+  case kF1 = 122
+  case kLeftArrow = 123
+  case kRightArrow = 124
+  case kDownArrow = 125
+  case kUpArrow = 126
+}
+
+enum KeyCodeBlackListed: UInt16 {
+  case kF17 = 64
+  case kVolumeUp = 72
+  case kVolumeDown = 73
+  case kMute = 74
+  case kF18 = 79
+  case kF19 = 80
+  case kF20 = 90
+  case kF5 = 96
+  case kF6 = 97
+  case kF7 = 98
+  case kF3 = 99
+  case kF8 = 100
+  case kF9 = 101
+  case kF11 = 103
+  case kF13 = 105 // PrtSc
+  case kF16 = 106
+  case kF14 = 107
+  case kF10 = 109
+  case kF12 = 111
+  case kF15 = 113
+  case kHelp = 114 // Insert
+  case kF4 = 118
+  case kF2 = 120
+  case kF1 = 122
+}
+
+// 摁 Alt+Shift+主鍵盤區域數字鍵 的話，根據不同的 macOS 鍵盤佈局種類，會出現不同的符號結果。
+// 然而呢，KeyCode 卻是一致的。於是這裡直接準備一個換算表來用。
+let mapMainAreaNumKey: [UInt16: String] = [
+  18: "1", 19: "2", 20: "3", 21: "4", 23: "5", 22: "6", 26: "7", 28: "8", 25: "9", 29: "0",
+]
+
+/// 數字小鍵盤區域的按鍵的 KeyCode。
+///
+/// 注意：第 95 號 Key Code（逗號）為 JIS 佈局特有的數字小鍵盤按鍵。
+let arrNumpadKeyCodes: [UInt16] = [65, 67, 69, 71, 75, 78, 81, 82, 83, 84, 85, 86, 87, 88, 89, 91, 92, 95]
+
+/// 主鍵盤區域的數字鍵的 KeyCode。
+let arrMainAreaNumKey: [UInt16] = [18, 19, 20, 21, 22, 23, 25, 26, 28, 29]
+
+// CharCodes: https://theasciicode.com.ar/ascii-control-characters/horizontal-tab-ascii-code-9.html
+enum CharCode: UInt16 {
+  case yajuusenpaiA = 114
+  case yajuusenpaiB = 514
+  case yajuusenpaiC = 1919
+  case yajuusenpaiD = 810
+  // CharCode is not reliable at all. KeyCode is the most appropriate choice due to its accuracy.
+  // KeyCode doesn't give a phuque about the character sent through macOS keyboard layouts ...
+  // ... but only focuses on which physical key is pressed.
+}
+
+// MARK: - Emacs CharCode-KeyCode translation tables.
+
+public enum EmacsKey {
+  static let charKeyMapHorizontal: [UInt16: UInt16] = [6: 124, 2: 123, 1: 115, 5: 119, 4: 117, 22: 121]
+  static let charKeyMapVertical: [UInt16: UInt16] = [6: 125, 2: 126, 1: 115, 5: 119, 4: 117, 22: 121]
+}

--- a/3rdParty/vChewingProject/CocoaExtension4RIME/CocoaExtension_NSEvent.swift
+++ b/3rdParty/vChewingProject/CocoaExtension4RIME/CocoaExtension_NSEvent.swift
@@ -47,7 +47,7 @@ public extension NSEvent {
   /// 自 Emacs 熱鍵的 NSEvent 翻譯回標準 NSEvent。失敗的話則會返回原始 NSEvent 自身。
   /// - Parameter isVerticalTyping: 是否按照縱排來操作。
   /// - Returns: 翻譯結果。失敗的話則返回翻譯原文。
-  func convertFromEmacKeyEvent(isVerticalContext: Bool) -> NSEvent {
+  func convertFromEmacsKeyEvent(isVerticalContext: Bool) -> NSEvent {
     guard isEmacsKey else { return self }
     let newKeyCode: UInt16 = {
       switch isVerticalContext {

--- a/3rdParty/vChewingProject/CocoaExtension4RIME/LICENSE
+++ b/3rdParty/vChewingProject/CocoaExtension4RIME/LICENSE
@@ -1,0 +1,24 @@
+MIT-NTL License
+
+(c) 2021 and onwards The vChewing Project (MIT-NTL License).
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+1. The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+2. No trademark license is granted to use the trade names, trademarks, service
+marks, or product names of Contributor, except as required to fulfill notice
+requirements above.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/3rdParty/vChewingProject/IMKUtils4RIME/IMKHelper.swift
+++ b/3rdParty/vChewingProject/IMKUtils4RIME/IMKHelper.swift
@@ -31,16 +31,7 @@ public enum IMKHelper {
   public static let arrDynamicBasicKeyLayouts: [String] = [
     "com.apple.keylayout.ZhuyinBopomofo",
     "com.apple.keylayout.ZhuyinEten",
-    "org.atelierInmu.vChewing.keyLayouts.vchewingdachen",
-    "org.atelierInmu.vChewing.keyLayouts.vchewingmitac",
-    "org.atelierInmu.vChewing.keyLayouts.vchewingibm",
-    "org.atelierInmu.vChewing.keyLayouts.vchewingseigyou",
-    "org.atelierInmu.vChewing.keyLayouts.vchewingeten",
-    "org.unknown.keylayout.vChewingDachen",
-    "org.unknown.keylayout.vChewingFakeSeigyou",
-    "org.unknown.keylayout.vChewingETen",
-    "org.unknown.keylayout.vChewingIBM",
-    "org.unknown.keylayout.vChewingMiTAC",
+    // 不是威注音输入法，就不用插入威注音自己的 keylayouts 了。
   ]
 
   public static var currentBasicKeyboardLayout: String {

--- a/3rdParty/vChewingProject/IMKUtils4RIME/IMKHelper.swift
+++ b/3rdParty/vChewingProject/IMKUtils4RIME/IMKHelper.swift
@@ -1,0 +1,248 @@
+// (c) 2022 and onwards The vChewing Project (MIT-NTL License).
+// ====================
+// This code is released under the MIT license (SPDX-License-Identifier: MIT)
+// ... with NTL restriction stating that:
+// No trademark license is granted to use the trade names, trademarks, service
+// marks, or product names of Contributor, except as required to fulfill notice
+// requirements defined in MIT License.
+
+// 注：該檔案的內容針對 RIME SQUIRREL 的開發需求做過調整，與威注音輸入法倉庫內建的檔案有所不同。
+
+import Foundation
+import InputMethodKit
+
+// MARK: - IMKHelper by The vChewing Project (MIT License).
+
+public enum IMKHelper {
+  /// 威注音有專門統計過，實際上會有差異的英數鍵盤佈局只有這幾種。
+  /// 精簡成這種清單的話，不但節省 SwiftUI 的繪製壓力，也方便使用者做選擇。
+  public static let arrWhitelistedKeyLayoutsASCII: [String] = [
+    "com.apple.keylayout.ABC",
+    "com.apple.keylayout.ABC-AZERTY",
+    "com.apple.keylayout.ABC-QWERTZ",
+    "com.apple.keylayout.British",
+    "com.apple.keylayout.Colemak",
+    "com.apple.keylayout.Dvorak",
+    "com.apple.keylayout.Dvorak-Left",
+    "com.apple.keylayout.DVORAK-QWERTYCMD",
+    "com.apple.keylayout.Dvorak-Right",
+  ]
+
+  public static let arrDynamicBasicKeyLayouts: [String] = [
+    "com.apple.keylayout.ZhuyinBopomofo",
+    "com.apple.keylayout.ZhuyinEten",
+    "org.atelierInmu.vChewing.keyLayouts.vchewingdachen",
+    "org.atelierInmu.vChewing.keyLayouts.vchewingmitac",
+    "org.atelierInmu.vChewing.keyLayouts.vchewingibm",
+    "org.atelierInmu.vChewing.keyLayouts.vchewingseigyou",
+    "org.atelierInmu.vChewing.keyLayouts.vchewingeten",
+    "org.unknown.keylayout.vChewingDachen",
+    "org.unknown.keylayout.vChewingFakeSeigyou",
+    "org.unknown.keylayout.vChewingETen",
+    "org.unknown.keylayout.vChewingIBM",
+    "org.unknown.keylayout.vChewingMiTAC",
+  ]
+
+  public static var currentBasicKeyboardLayout: String {
+    get {
+      UserDefaults.standard.string(forKey: "BasicKeyboardLayout") ?? ""
+    } set {
+      // 當且僅當輸入數值有效的時候，才會寫入數值。否則就無視之。
+      if let _ = TISInputSource.generate(from: newValue) {
+        UserDefaults.standard.set(newValue, forKey: "BasicKeyboardLayout")
+      }
+    }
+  }
+
+  public static var isDynamicBasicKeyboardLayoutEnabled: Bool {
+    Self.arrDynamicBasicKeyLayouts.contains(currentBasicKeyboardLayout) || !currentBasicKeyboardLayout.isEmpty
+  }
+
+  public static var allowedAlphanumericalTISInputSources: [TISInputSource] {
+    arrWhitelistedKeyLayoutsASCII.compactMap { TISInputSource.generate(from: $0) }
+  }
+
+  public static var allowedBasicLayoutsAsTISInputSources: [TISInputSource?] {
+    // 為了保證清單順序，先弄兩個容器。
+    var containerA: [TISInputSource?] = []
+    var containerB: [TISInputSource?] = []
+    var containerC: [TISInputSource?] = []
+
+    let rawDictionary = TISInputSource.rawTISInputSources(onlyASCII: false)
+
+    Self.arrWhitelistedKeyLayoutsASCII.forEach {
+      if let neta = rawDictionary[$0], !arrDynamicBasicKeyLayouts.contains(neta.identifier) {
+        containerC.append(neta)
+      }
+    }
+
+    Self.arrDynamicBasicKeyLayouts.forEach {
+      if let neta = rawDictionary[$0] {
+        if neta.identifier.contains("com.apple") {
+          containerA.append(neta)
+        } else {
+          containerB.append(neta)
+        }
+      }
+    }
+
+    // 這裡的 nil 是用來讓選單插入分隔符用的。
+    if !containerA.isEmpty { containerA.append(nil) }
+    if !containerB.isEmpty { containerB.append(nil) }
+
+    return containerA + containerB + containerC
+  }
+
+  public struct CarbonKeyboardLayout {
+    var strName: String = ""
+    var strValue: String = ""
+  }
+}
+
+// MARK: - 與輸入法的具體的安裝過程有關的命令
+
+public extension IMKHelper {
+  @discardableResult static func registerInputMethod() -> Int32 {
+    TISInputSource.registerInputMethod() ? 0 : -1
+  }
+}
+
+// MARK: - Apple Keyboard Converter
+
+public extension NSEvent {
+  func convertedFromPhonabets(ignoringModifiers: Bool = false) -> String {
+    if type == .flagsChanged { return "" }
+    var strProcessed = charactersIgnoringModifiers ?? characters ?? ""
+    if !ignoringModifiers {
+      strProcessed = characters ?? ""
+    }
+    if IMKHelper.isDynamicBasicKeyboardLayoutEnabled {
+      // 針對不同的 Apple 動態鍵盤佈局糾正大寫英文輸入。
+      switch IMKHelper.currentBasicKeyboardLayout {
+      case "com.apple.keylayout.ZhuyinBopomofo":
+        if strProcessed.count == 1, Character(strProcessed).isLowercase, Character(strProcessed).isASCII {
+          strProcessed = strProcessed.uppercased()
+        }
+      case "com.apple.keylayout.ZhuyinEten":
+        switch strProcessed {
+        case "ａ": strProcessed = "A"
+        case "ｂ": strProcessed = "B"
+        case "ｃ": strProcessed = "C"
+        case "ｄ": strProcessed = "D"
+        case "ｅ": strProcessed = "E"
+        case "ｆ": strProcessed = "F"
+        case "ｇ": strProcessed = "G"
+        case "ｈ": strProcessed = "H"
+        case "ｉ": strProcessed = "I"
+        case "ｊ": strProcessed = "J"
+        case "ｋ": strProcessed = "K"
+        case "ｌ": strProcessed = "L"
+        case "ｍ": strProcessed = "M"
+        case "ｎ": strProcessed = "N"
+        case "ｏ": strProcessed = "O"
+        case "ｐ": strProcessed = "P"
+        case "ｑ": strProcessed = "Q"
+        case "ｒ": strProcessed = "R"
+        case "ｓ": strProcessed = "S"
+        case "ｔ": strProcessed = "T"
+        case "ｕ": strProcessed = "U"
+        case "ｖ": strProcessed = "V"
+        case "ｗ": strProcessed = "W"
+        case "ｘ": strProcessed = "X"
+        case "ｙ": strProcessed = "Y"
+        case "ｚ": strProcessed = "Z"
+        default: break
+        }
+      default: break
+      }
+      // 注音鍵群。
+      switch strProcessed {
+      case "ㄝ": strProcessed = ","
+      case "ㄦ": strProcessed = "-"
+      case "ㄡ": strProcessed = "."
+      case "ㄥ": strProcessed = "/"
+      case "ㄢ": strProcessed = "0"
+      case "ㄅ": strProcessed = "1"
+      case "ㄉ": strProcessed = "2"
+      case "ˇ": strProcessed = "3"
+      case "ˋ": strProcessed = "4"
+      case "ㄓ": strProcessed = "5"
+      case "ˊ": strProcessed = "6"
+      case "˙": strProcessed = "7"
+      case "ㄚ": strProcessed = "8"
+      case "ㄞ": strProcessed = "9"
+      case "ㄤ": strProcessed = ";"
+      case "ㄇ": strProcessed = "a"
+      case "ㄖ": strProcessed = "b"
+      case "ㄏ": strProcessed = "c"
+      case "ㄎ": strProcessed = "d"
+      case "ㄍ": strProcessed = "e"
+      case "ㄑ": strProcessed = "f"
+      case "ㄕ": strProcessed = "g"
+      case "ㄘ": strProcessed = "h"
+      case "ㄛ": strProcessed = "i"
+      case "ㄨ": strProcessed = "j"
+      case "ㄜ": strProcessed = "k"
+      case "ㄠ": strProcessed = "l"
+      case "ㄩ": strProcessed = "m"
+      case "ㄙ": strProcessed = "n"
+      case "ㄟ": strProcessed = "o"
+      case "ㄣ": strProcessed = "p"
+      case "ㄆ": strProcessed = "q"
+      case "ㄐ": strProcessed = "r"
+      case "ㄋ": strProcessed = "s"
+      case "ㄔ": strProcessed = "t"
+      case "ㄧ": strProcessed = "u"
+      case "ㄒ": strProcessed = "v"
+      case "ㄊ": strProcessed = "w"
+      case "ㄌ": strProcessed = "x"
+      case "ㄗ": strProcessed = "y"
+      case "ㄈ": strProcessed = "z"
+      default: break
+      }
+      // 除了數字鍵區以外的標點符號。
+      switch strProcessed {
+      case "、": strProcessed = "\\"
+      case "「": strProcessed = "["
+      case "」": strProcessed = "]"
+      case "『": strProcessed = "{"
+      case "』": strProcessed = "}"
+      case "，": strProcessed = "<"
+      case "。": strProcessed = ">"
+      default: break
+      }
+      // 摁了 SHIFT 之後的數字區的符號。
+      switch strProcessed {
+      case "！": strProcessed = "!"
+      case "＠": strProcessed = "@"
+      case "＃": strProcessed = "#"
+      case "＄": strProcessed = "$"
+      case "％": strProcessed = "%"
+      case "︿": strProcessed = "^"
+      case "＆": strProcessed = "&"
+      case "＊": strProcessed = "*"
+      case "（": strProcessed = "("
+      case "）": strProcessed = ")"
+      default: break
+      }
+      // 摁了 Alt 的符號。
+      if strProcessed == "—" { strProcessed = "-" }
+      // Apple 倚天注音佈局追加符號糾正項目。
+      if IMKHelper.currentBasicKeyboardLayout == "com.apple.keylayout.ZhuyinEten" {
+        switch strProcessed {
+        case "＿": strProcessed = "_"
+        case "：": strProcessed = ":"
+        case "？": strProcessed = "?"
+        case "＋": strProcessed = "+"
+        case "｜": strProcessed = "|"
+        default: break
+        }
+      }
+      // 糾正 macOS 內建的的動態注音鍵盤佈局的一個 bug。
+      if "-·".contains(strProcessed), keyCode == 50 {
+        strProcessed = "`"
+      }
+    }
+    return strProcessed
+  }
+}

--- a/3rdParty/vChewingProject/IMKUtils4RIME/LICENSE
+++ b/3rdParty/vChewingProject/IMKUtils4RIME/LICENSE
@@ -1,0 +1,24 @@
+MIT-NTL License
+
+(c) 2021 and onwards The vChewing Project (MIT-NTL License).
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+1. The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+2. No trademark license is granted to use the trade names, trademarks, service
+marks, or product names of Contributor, except as required to fulfill notice
+requirements above.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/3rdParty/vChewingProject/IMKUtils4RIME/TISInputSourceExtension.swift
+++ b/3rdParty/vChewingProject/IMKUtils4RIME/TISInputSourceExtension.swift
@@ -1,0 +1,149 @@
+// (c) 2021 and onwards The vChewing Project (MIT-NTL License).
+// ====================
+// This code is released under the MIT license (SPDX-License-Identifier: MIT)
+// ... with NTL restriction stating that:
+// No trademark license is granted to use the trade names, trademarks, service
+// marks, or product names of Contributor, except as required to fulfill notice
+// requirements defined in MIT License.
+
+import Foundation
+import InputMethodKit
+
+// MARK: - TISInputSource Extension by The vChewing Project (MIT-NTL License).
+
+public extension TISInputSource {
+  static var allRegisteredInstancesOfThisInputMethod: [TISInputSource] {
+    TISInputSource.modes.compactMap { TISInputSource.generate(from: $0) }
+  }
+
+  static var modes: [String] {
+    guard let components = Bundle.main.infoDictionary?["ComponentInputModeDict"] as? [String: Any],
+          let tsInputModeListKey = components["tsInputModeListKey"] as? [String: Any]
+    else {
+      return []
+    }
+    return tsInputModeListKey.keys.map { $0 }
+  }
+
+  @discardableResult static func registerInputMethod() -> Bool {
+    let instances = TISInputSource.allRegisteredInstancesOfThisInputMethod
+    if instances.isEmpty {
+      // 有實例尚未登記。執行登記手續。
+      NSLog("Registering input source.")
+      if !TISInputSource.registerInputSource() {
+        NSLog("Input source registration failed.")
+        return false
+      }
+    }
+    var succeeded = true
+    instances.forEach {
+      NSLog("Enabling input source: \($0.identifier)")
+      if !$0.activate() {
+        NSLog("Failed from enabling input source: \($0.identifier)")
+        succeeded = false
+      }
+    }
+    return succeeded
+  }
+
+  @discardableResult static func registerInputSource() -> Bool {
+    TISRegisterInputSource(Bundle.main.bundleURL as CFURL) == noErr
+  }
+
+  @discardableResult func activate() -> Bool {
+    TISEnableInputSource(self) == noErr
+  }
+
+  @discardableResult func select() -> Bool {
+    if !isSelectable {
+      NSLog("Non-selectable: \(identifier)")
+      return false
+    }
+    if TISSelectInputSource(self) != noErr {
+      NSLog("Failed from switching to \(identifier)")
+      return false
+    }
+    return true
+  }
+
+  @discardableResult func deactivate() -> Bool {
+    TISDisableInputSource(self) == noErr
+  }
+
+  var isActivated: Bool {
+    unsafeBitCast(TISGetInputSourceProperty(self, kTISPropertyInputSourceIsEnabled), to: CFBoolean.self)
+      == kCFBooleanTrue
+  }
+
+  var isSelectable: Bool {
+    unsafeBitCast(TISGetInputSourceProperty(self, kTISPropertyInputSourceIsSelectCapable), to: CFBoolean.self)
+      == kCFBooleanTrue
+  }
+
+  static func generate(from identifier: String) -> TISInputSource? {
+    TISInputSource.rawTISInputSources(onlyASCII: false)[identifier]
+  }
+
+  var inputModeID: String {
+    unsafeBitCast(TISGetInputSourceProperty(self, kTISPropertyInputModeID), to: NSString.self) as String
+  }
+
+  var vChewingLocalizedName: String {
+    switch identifier {
+    case "com.apple.keylayout.ZhuyinBopomofo":
+      return NSLocalizedString("Apple Zhuyin Bopomofo (Dachen)", comment: "")
+    case "com.apple.keylayout.ZhuyinEten":
+      return NSLocalizedString("Apple Zhuyin Eten (Traditional)", comment: "")
+    default: return localizedName
+    }
+  }
+}
+
+// MARK: - TISInputSource Extension by Mizuno Hiroki (a.k.a. "Mzp") (MIT License)
+
+// Ref: Original source codes are written in Swift 4 from Mzp's InputMethodKit textbook.
+// Note: Slightly modified by vChewing Project: Using Dictionaries when necessary.
+
+public extension TISInputSource {
+  var localizedName: String {
+    unsafeBitCast(TISGetInputSourceProperty(self, kTISPropertyLocalizedName), to: NSString.self) as String
+  }
+
+  var identifier: String {
+    unsafeBitCast(TISGetInputSourceProperty(self, kTISPropertyInputSourceID), to: NSString.self) as String
+  }
+
+  var scriptCode: Int {
+    let r = TISGetInputSourceProperty(self, "TSMInputSourcePropertyScriptCode" as CFString)
+    return unsafeBitCast(r, to: NSString.self).integerValue
+  }
+
+  static func rawTISInputSources(onlyASCII: Bool = false) -> [String: TISInputSource] {
+    // 為了指定檢索條件，先構築 CFDictionary 辭典。
+    // 第二項代指辭典容量。
+    let conditions = CFDictionaryCreateMutable(nil, 2, nil, nil)
+    if onlyASCII {
+      // 第一條件：僅接收靜態鍵盤佈局結果。
+      CFDictionaryAddValue(
+        conditions, unsafeBitCast(kTISPropertyInputSourceType, to: UnsafeRawPointer.self),
+        unsafeBitCast(kTISTypeKeyboardLayout, to: UnsafeRawPointer.self)
+      )
+      // 第二條件：只能輸入 ASCII 內容。
+      CFDictionaryAddValue(
+        conditions, unsafeBitCast(kTISPropertyInputSourceIsASCIICapable, to: UnsafeRawPointer.self),
+        unsafeBitCast(kCFBooleanTrue, to: UnsafeRawPointer.self)
+      )
+    }
+    // 返回鍵盤配列清單。
+    var result = TISCreateInputSourceList(conditions, true).takeRetainedValue() as? [TISInputSource] ?? .init()
+    if onlyASCII {
+      result = result.filter { $0.scriptCode == 0 }
+    }
+    var resultDictionary: [String: TISInputSource] = [:]
+    result.forEach {
+      resultDictionary[$0.inputModeID] = $0
+      resultDictionary[$0.identifier] = $0
+    }
+    return resultDictionary
+  }
+}

--- a/3rdParty/vChewingProject/IMKUtils4RIME/TISInputSourceExtension.swift
+++ b/3rdParty/vChewingProject/IMKUtils4RIME/TISInputSourceExtension.swift
@@ -87,16 +87,6 @@ public extension TISInputSource {
   var inputModeID: String {
     unsafeBitCast(TISGetInputSourceProperty(self, kTISPropertyInputModeID), to: NSString.self) as String
   }
-
-  var vChewingLocalizedName: String {
-    switch identifier {
-    case "com.apple.keylayout.ZhuyinBopomofo":
-      return NSLocalizedString("Apple Zhuyin Bopomofo (Dachen)", comment: "")
-    case "com.apple.keylayout.ZhuyinEten":
-      return NSLocalizedString("Apple Zhuyin Eten (Traditional)", comment: "")
-    default: return localizedName
-    }
-  }
 }
 
 // MARK: - TISInputSource Extension by Mizuno Hiroki (a.k.a. "Mzp") (MIT License)

--- a/3rdParty/vChewingProject/SwiftExtension4RIME/LICENSE
+++ b/3rdParty/vChewingProject/SwiftExtension4RIME/LICENSE
@@ -1,0 +1,24 @@
+MIT-NTL License
+
+(c) 2021 and onwards The vChewing Project (MIT-NTL License).
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+1. The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+2. No trademark license is granted to use the trade names, trademarks, service
+marks, or product names of Contributor, except as required to fulfill notice
+requirements above.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/3rdParty/vChewingProject/SwiftExtension4RIME/SwiftExtension.swift
+++ b/3rdParty/vChewingProject/SwiftExtension4RIME/SwiftExtension.swift
@@ -1,0 +1,131 @@
+// (c) 2021 and onwards The vChewing Project (MIT-NTL License).
+// ====================
+// This code is released under the MIT license (SPDX-License-Identifier: MIT)
+// ... with NTL restriction stating that:
+// No trademark license is granted to use the trade names, trademarks, service
+// marks, or product names of Contributor, except as required to fulfill notice
+// requirements defined in MIT License.
+
+import Foundation
+
+// MARK: - Root Extensions
+
+// Extend the RangeReplaceableCollection to allow it clean duplicated characters.
+// Ref: https://stackoverflow.com/questions/25738817/
+public extension RangeReplaceableCollection where Element: Hashable {
+  var deduplicated: Self {
+    var set = Set<Element>()
+    return filter { set.insert($0).inserted }
+  }
+}
+
+// MARK: - String charComponents Extension
+
+public extension String {
+  var charComponents: [String] { map { String($0) } }
+}
+
+public extension Array where Element == String.Element {
+  var charComponents: [String] { map { String($0) } }
+}
+
+// MARK: - String Tildes Expansion Extension
+
+public extension String {
+  var expandingTildeInPath: String {
+    (self as NSString).expandingTildeInPath
+  }
+}
+
+// MARK: - String Localized Error Extension
+
+extension String: LocalizedError {
+  public var errorDescription: String? {
+    self
+  }
+}
+
+// MARK: - Ensuring trailing slash of a string
+
+public extension String {
+  mutating func ensureTrailingSlash() {
+    if !hasSuffix("/") {
+      self += "/"
+    }
+  }
+}
+
+// MARK: - CharCode printability check
+
+// Ref: https://forums.swift.org/t/57085/5
+public extension UniChar {
+  var isPrintable: Bool {
+    guard Unicode.Scalar(UInt32(self)) != nil else {
+      struct NotAWholeScalar: Error {}
+      return false
+    }
+    return true
+  }
+
+  var isPrintableASCII: Bool {
+    (32 ... 126).contains(self)
+  }
+}
+
+// MARK: - Stable Sort Extension
+
+// Ref: https://stackoverflow.com/a/50545761/4162914
+public extension Sequence {
+  /// Return a stable-sorted collection.
+  ///
+  /// - Parameter areInIncreasingOrder: Return nil when two element are equal.
+  /// - Returns: The sorted collection.
+  func stableSort(
+    by areInIncreasingOrder: (Element, Element) throws -> Bool
+  )
+    rethrows -> [Element]
+  {
+    try enumerated()
+      .sorted { a, b -> Bool in
+        try areInIncreasingOrder(a.element, b.element)
+          || (a.offset < b.offset && !areInIncreasingOrder(b.element, a.element))
+      }
+      .map(\.element)
+  }
+}
+
+// MARK: - Return toggled value.
+
+public extension Bool {
+  mutating func toggled() -> Bool {
+    toggle()
+    return self
+  }
+}
+
+// MARK: - Property wrapper
+
+// Ref: https://www.avanderlee.com/swift/property-wrappers/
+
+@propertyWrapper
+public struct AppProperty<Value> {
+  public let key: String
+  public let defaultValue: Value
+  public var container: UserDefaults = .standard
+  public init(key: String, defaultValue: Value) {
+    self.key = key
+    self.defaultValue = defaultValue
+    if container.object(forKey: key) == nil {
+      container.set(defaultValue, forKey: key)
+    }
+  }
+
+  public var wrappedValue: Value {
+    get {
+      container.object(forKey: key) as? Value ?? defaultValue
+    }
+    set {
+      container.set(newValue, forKey: key)
+    }
+  }
+}

--- a/3rdParty/vChewingProject/SwiftExtension4RIME/SwiftExtension.swift
+++ b/3rdParty/vChewingProject/SwiftExtension4RIME/SwiftExtension.swift
@@ -90,7 +90,7 @@ public extension Sequence {
         try areInIncreasingOrder(a.element, b.element)
           || (a.offset < b.offset && !areInIncreasingOrder(b.element, a.element))
       }
-      .map(\.element)
+      .map { $0.element }
   }
 }
 

--- a/Base.lproj/SquirrelSettingsWindow.xib
+++ b/Base.lproj/SquirrelSettingsWindow.xib
@@ -21,7 +21,7 @@
             <rect key="screenRect" x="0.0" y="0.0" width="1440" height="875"/>
             <view key="contentView" id="se5-gp-TjO">
                 <rect key="frame" x="0.0" y="0.0" width="381" height="82"/>
-                <autoresizingMask key="autoresizingMask"/>
+                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                 <subviews>
                     <stackView distribution="fill" orientation="horizontal" alignment="top" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" fixedFrame="YES" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="icc-tr-Rcw">
                         <rect key="frame" x="20" y="20" width="330" height="20"/>

--- a/Makefile
+++ b/Makefile
@@ -137,3 +137,6 @@ clean:
 clean-deps:
 	$(MAKE) -C plum clean
 	$(MAKE) -C librime xcode/clean
+
+swiftformat:
+	@swiftformat --swiftversion 5.0 --indent 2 ./

--- a/Properties.swift
+++ b/Properties.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+@objc public class Properties: NSObject {
+  @objc public static let shared = Properties()
+
+  @AppProperty(key: "BasicKeyboardLayout", defaultValue: "")
+  public var basicKeyboardLayout: String
+}

--- a/Properties.swift
+++ b/Properties.swift
@@ -2,7 +2,8 @@ import Foundation
 
 @objc public class Properties: NSObject {
   @objc public static let shared = Properties()
+  public static let kDefaultBasicKeyboardLayout = "com.apple.keylayout.ABC"
 
-  @AppProperty(key: "BasicKeyboardLayout", defaultValue: "")
+  @AppProperty(key: "BasicKeyboardLayout", defaultValue: "kDefaultBasicKeyboardLayout")
   public var basicKeyboardLayout: String
 }

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@
   * Junlu Cheng
   * Jak Wings
   * xiehuc
+  * Shiki Suen (vChewing Project)
 
 美術：
 
@@ -93,6 +94,9 @@
   * Sparkle  (MIT License)
   * UTF8-CPP  (Boost Software License)
   * yaml-cpp  (MIT License)
+  * vChewing CocoaExtension (MIT-NTL License)  // Rime 客製化版本
+  * vChewing SwiftExtension (MIT-NTL License)  // Rime 客製化版本
+  * vChewing IMKUtils (MIT-NTL License)  // Rime 客製化版本
 
 感謝王公子捐贈開發用機。
 

--- a/Squirrel-Bridging-Header.h
+++ b/Squirrel-Bridging-Header.h
@@ -1,0 +1,5 @@
+//
+//  Use this file to import your target's public headers that you would like to expose to Swift.
+//
+
+#import "SquirrelInputController.h"

--- a/Squirrel-Bridging-Header.h
+++ b/Squirrel-Bridging-Header.h
@@ -3,3 +3,4 @@
 //
 
 #import "SquirrelInputController.h"
+#import "SquirrelApplicationDelegate.h"

--- a/Squirrel.xcodeproj/project.pbxproj
+++ b/Squirrel.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		44E98EC314AE1AC900847AD6 /* utf8.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 44E98EC214AE1AC900847AD6 /* utf8.cpp */; };
 		44F7708F152B3334005CF491 /* dsa_pub.pem in Resources */ = {isa = PBXBuildFile; fileRef = 44F7708E152B3334005CF491 /* dsa_pub.pem */; };
 		44F84AD714E94C490005D70B /* SquirrelPanel.m in Sources */ = {isa = PBXBuildFile; fileRef = 44F84AD614E94C490005D70B /* SquirrelPanel.m */; };
+		5B05EDBA28F134B600B50058 /* SquirrelSettingsWindow.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5B05EDBC28F134B600B50058 /* SquirrelSettingsWindow.xib */; };
 		5B511F1C28EEC25D0019E25B /* SquirrelInputController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B511F1B28EEC25D0019E25B /* SquirrelInputController.swift */; };
 		5B511F2928EEC27A0019E25B /* CocoaExtension_NSEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B511F1F28EEC27A0019E25B /* CocoaExtension_NSEvent.swift */; };
 		5B511F2A28EEC27A0019E25B /* CocoaExtension_Misc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B511F2028EEC27A0019E25B /* CocoaExtension_Misc.swift */; };
@@ -47,7 +48,6 @@
 		5BA2241228EECC5C004DCA14 /* SquirrelInputController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA2241128EECC5C004DCA14 /* SquirrelInputController.swift */; };
 		5BA2241428EED286004DCA14 /* Properties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA2241328EED286004DCA14 /* Properties.swift */; };
 		5BB868C528F08081002FAEEC /* SquirrelSettingsWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB868C328F08081002FAEEC /* SquirrelSettingsWindow.swift */; };
-		5BB868C628F08081002FAEEC /* SquirrelSettingsWindow.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5BB868C428F08081002FAEEC /* SquirrelSettingsWindow.xib */; };
 		77AA68142588916F00A592E2 /* hk2s.json in Copy opencc Files */ = {isa = PBXBuildFile; fileRef = 77AA67E22588916300A592E2 /* hk2s.json */; };
 		77AA68152588916F00A592E2 /* HKVariants.ocd2 in Copy opencc Files */ = {isa = PBXBuildFile; fileRef = 77AA67DC2588916300A592E2 /* HKVariants.ocd2 */; };
 		77AA68162588916F00A592E2 /* HKVariantsRev.ocd2 in Copy opencc Files */ = {isa = PBXBuildFile; fileRef = 77AA67E02588916300A592E2 /* HKVariantsRev.ocd2 */; };
@@ -247,6 +247,10 @@
 		44F84AD614E94C490005D70B /* SquirrelPanel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SquirrelPanel.m; sourceTree = "<group>"; };
 		44FA4D891685997300116C1F /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		44FA4D8E16859B2900116C1F /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/Localizable.strings"; sourceTree = "<group>"; };
+		5B05EDBE28F134B900B50058 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/SquirrelSettingsWindow.strings"; sourceTree = "<group>"; };
+		5B05EDC028F134BA00B50058 /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/SquirrelSettingsWindow.strings"; sourceTree = "<group>"; };
+		5B05EDC128F1355000B50058 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/SquirrelSettingsWindow.xib; sourceTree = "<group>"; };
+		5B05EDC228F1355500B50058 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/SquirrelSettingsWindow.strings; sourceTree = "<group>"; };
 		5B511F1A28EEC25D0019E25B /* Squirrel-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Squirrel-Bridging-Header.h"; sourceTree = "<group>"; };
 		5B511F1B28EEC25D0019E25B /* SquirrelInputController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SquirrelInputController.swift; sourceTree = "<group>"; };
 		5B511F1E28EEC27A0019E25B /* LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
@@ -260,7 +264,6 @@
 		5BA2241128EECC5C004DCA14 /* SquirrelInputController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SquirrelInputController.swift; sourceTree = "<group>"; };
 		5BA2241328EED286004DCA14 /* Properties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Properties.swift; sourceTree = "<group>"; };
 		5BB868C328F08081002FAEEC /* SquirrelSettingsWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SquirrelSettingsWindow.swift; sourceTree = "<group>"; };
-		5BB868C428F08081002FAEEC /* SquirrelSettingsWindow.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SquirrelSettingsWindow.xib; sourceTree = "<group>"; };
 		77AA67DC2588916300A592E2 /* HKVariants.ocd2 */ = {isa = PBXFileReference; lastKnownFileType = file; path = HKVariants.ocd2; sourceTree = "<group>"; };
 		77AA67DD2588916300A592E2 /* t2s.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = t2s.json; sourceTree = "<group>"; };
 		77AA67DE2588916300A592E2 /* t2tw.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = t2tw.json; sourceTree = "<group>"; };
@@ -408,7 +411,7 @@
 				A45578F41146A75200592C6E /* MainMenu.xib */,
 				446C01D61F767BD400A6C23E /* Assets.xcassets */,
 				5BB868C328F08081002FAEEC /* SquirrelSettingsWindow.swift */,
-				5BB868C428F08081002FAEEC /* SquirrelSettingsWindow.xib */,
+				5B05EDBC28F134B600B50058 /* SquirrelSettingsWindow.xib */,
 			);
 			name = Resources;
 			sourceTree = "<group>";
@@ -637,7 +640,7 @@
 				A4FC48CB0F6530EF0069BE81 /* Localizable.strings in Resources */,
 				44986A95184B421700B3278D /* LICENSE.txt in Resources */,
 				44986A96184B421700B3278D /* README.md in Resources */,
-				5BB868C628F08081002FAEEC /* SquirrelSettingsWindow.xib in Resources */,
+				5B05EDBA28F134B600B50058 /* SquirrelSettingsWindow.xib in Resources */,
 				44F7708F152B3334005CF491 /* dsa_pub.pem in Resources */,
 				44CD7D9F1828D981006E9222 /* rime.pdf in Resources */,
 			);
@@ -681,6 +684,17 @@
 				446D18E114F0193100EC3116 /* zh-Hant */,
 			);
 			name = InfoPlist.strings;
+			sourceTree = "<group>";
+		};
+		5B05EDBC28F134B600B50058 /* SquirrelSettingsWindow.xib */ = {
+			isa = PBXVariantGroup;
+			children = (
+				5B05EDBE28F134B900B50058 /* zh-Hans */,
+				5B05EDC028F134BA00B50058 /* zh-Hant */,
+				5B05EDC128F1355000B50058 /* Base */,
+				5B05EDC228F1355500B50058 /* en */,
+			);
+			name = SquirrelSettingsWindow.xib;
 			sourceTree = "<group>";
 		};
 		A45578F41146A75200592C6E /* MainMenu.xib */ = {

--- a/Squirrel.xcodeproj/project.pbxproj
+++ b/Squirrel.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		5B511F2E28EEC27A0019E25B /* IMKHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B511F2628EEC27A0019E25B /* IMKHelper.swift */; };
 		5B511F2F28EEC27A0019E25B /* TISInputSourceExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B511F2728EEC27A0019E25B /* TISInputSourceExtension.swift */; };
 		5BA2241228EECC5C004DCA14 /* SquirrelInputController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA2241128EECC5C004DCA14 /* SquirrelInputController.swift */; };
+		5BA2241428EED286004DCA14 /* Properties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA2241328EED286004DCA14 /* Properties.swift */; };
 		77AA68142588916F00A592E2 /* hk2s.json in Copy opencc Files */ = {isa = PBXBuildFile; fileRef = 77AA67E22588916300A592E2 /* hk2s.json */; };
 		77AA68152588916F00A592E2 /* HKVariants.ocd2 in Copy opencc Files */ = {isa = PBXBuildFile; fileRef = 77AA67DC2588916300A592E2 /* HKVariants.ocd2 */; };
 		77AA68162588916F00A592E2 /* HKVariantsRev.ocd2 in Copy opencc Files */ = {isa = PBXBuildFile; fileRef = 77AA67E02588916300A592E2 /* HKVariantsRev.ocd2 */; };
@@ -255,6 +256,7 @@
 		5B511F2628EEC27A0019E25B /* IMKHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IMKHelper.swift; sourceTree = "<group>"; };
 		5B511F2728EEC27A0019E25B /* TISInputSourceExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TISInputSourceExtension.swift; sourceTree = "<group>"; };
 		5BA2241128EECC5C004DCA14 /* SquirrelInputController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SquirrelInputController.swift; sourceTree = "<group>"; };
+		5BA2241328EED286004DCA14 /* Properties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Properties.swift; sourceTree = "<group>"; };
 		77AA67DC2588916300A592E2 /* HKVariants.ocd2 */ = {isa = PBXFileReference; lastKnownFileType = file; path = HKVariants.ocd2; sourceTree = "<group>"; };
 		77AA67DD2588916300A592E2 /* t2s.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = t2s.json; sourceTree = "<group>"; };
 		77AA67DE2588916300A592E2 /* t2tw.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = t2tw.json; sourceTree = "<group>"; };
@@ -321,6 +323,7 @@
 			isa = PBXGroup;
 			children = (
 				44E98EA414AE16DD00847AD6 /* utf8 */,
+				5BA2241328EED286004DCA14 /* Properties.swift */,
 				44AC95161430CF6000C888FB /* SquirrelApplicationDelegate.h */,
 				44AC95171430CF6000C888FB /* SquirrelApplicationDelegate.m */,
 				44AC95181430CF6000C888FB /* SquirrelInputController.h */,
@@ -648,6 +651,7 @@
 				5B511F2C28EEC27A0019E25B /* SwiftExtension.swift in Sources */,
 				44AC951B1430CF6000C888FB /* SquirrelInputController.m in Sources */,
 				44E98EC314AE1AC900847AD6 /* utf8.cpp in Sources */,
+				5BA2241428EED286004DCA14 /* Properties.swift in Sources */,
 				5B511F1C28EEC25D0019E25B /* SquirrelInputController.swift in Sources */,
 				4443A83A1828CC5100731305 /* input_source.m in Sources */,
 				5B511F2F28EEC27A0019E25B /* TISInputSourceExtension.swift in Sources */,

--- a/Squirrel.xcodeproj/project.pbxproj
+++ b/Squirrel.xcodeproj/project.pbxproj
@@ -46,6 +46,8 @@
 		5B511F2F28EEC27A0019E25B /* TISInputSourceExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B511F2728EEC27A0019E25B /* TISInputSourceExtension.swift */; };
 		5BA2241228EECC5C004DCA14 /* SquirrelInputController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA2241128EECC5C004DCA14 /* SquirrelInputController.swift */; };
 		5BA2241428EED286004DCA14 /* Properties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA2241328EED286004DCA14 /* Properties.swift */; };
+		5BB868C528F08081002FAEEC /* SquirrelSettingsWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB868C328F08081002FAEEC /* SquirrelSettingsWindow.swift */; };
+		5BB868C628F08081002FAEEC /* SquirrelSettingsWindow.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5BB868C428F08081002FAEEC /* SquirrelSettingsWindow.xib */; };
 		77AA68142588916F00A592E2 /* hk2s.json in Copy opencc Files */ = {isa = PBXBuildFile; fileRef = 77AA67E22588916300A592E2 /* hk2s.json */; };
 		77AA68152588916F00A592E2 /* HKVariants.ocd2 in Copy opencc Files */ = {isa = PBXBuildFile; fileRef = 77AA67DC2588916300A592E2 /* HKVariants.ocd2 */; };
 		77AA68162588916F00A592E2 /* HKVariantsRev.ocd2 in Copy opencc Files */ = {isa = PBXBuildFile; fileRef = 77AA67E02588916300A592E2 /* HKVariantsRev.ocd2 */; };
@@ -257,6 +259,8 @@
 		5B511F2728EEC27A0019E25B /* TISInputSourceExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TISInputSourceExtension.swift; sourceTree = "<group>"; };
 		5BA2241128EECC5C004DCA14 /* SquirrelInputController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SquirrelInputController.swift; sourceTree = "<group>"; };
 		5BA2241328EED286004DCA14 /* Properties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Properties.swift; sourceTree = "<group>"; };
+		5BB868C328F08081002FAEEC /* SquirrelSettingsWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SquirrelSettingsWindow.swift; sourceTree = "<group>"; };
+		5BB868C428F08081002FAEEC /* SquirrelSettingsWindow.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SquirrelSettingsWindow.xib; sourceTree = "<group>"; };
 		77AA67DC2588916300A592E2 /* HKVariants.ocd2 */ = {isa = PBXFileReference; lastKnownFileType = file; path = HKVariants.ocd2; sourceTree = "<group>"; };
 		77AA67DD2588916300A592E2 /* t2s.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = t2s.json; sourceTree = "<group>"; };
 		77AA67DE2588916300A592E2 /* t2tw.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = t2tw.json; sourceTree = "<group>"; };
@@ -403,6 +407,8 @@
 				089C165CFE840E0CC02AAC07 /* InfoPlist.strings */,
 				A45578F41146A75200592C6E /* MainMenu.xib */,
 				446C01D61F767BD400A6C23E /* Assets.xcassets */,
+				5BB868C328F08081002FAEEC /* SquirrelSettingsWindow.swift */,
+				5BB868C428F08081002FAEEC /* SquirrelSettingsWindow.xib */,
 			);
 			name = Resources;
 			sourceTree = "<group>";
@@ -631,6 +637,7 @@
 				A4FC48CB0F6530EF0069BE81 /* Localizable.strings in Resources */,
 				44986A95184B421700B3278D /* LICENSE.txt in Resources */,
 				44986A96184B421700B3278D /* README.md in Resources */,
+				5BB868C628F08081002FAEEC /* SquirrelSettingsWindow.xib in Resources */,
 				44F7708F152B3334005CF491 /* dsa_pub.pem in Resources */,
 				44CD7D9F1828D981006E9222 /* rime.pdf in Resources */,
 			);
@@ -654,6 +661,7 @@
 				5BA2241428EED286004DCA14 /* Properties.swift in Sources */,
 				5B511F1C28EEC25D0019E25B /* SquirrelInputController.swift in Sources */,
 				4443A83A1828CC5100731305 /* input_source.m in Sources */,
+				5BB868C528F08081002FAEEC /* SquirrelSettingsWindow.swift in Sources */,
 				5B511F2F28EEC27A0019E25B /* TISInputSourceExtension.swift in Sources */,
 				5B511F2A28EEC27A0019E25B /* CocoaExtension_Misc.swift in Sources */,
 				5BA2241228EECC5C004DCA14 /* SquirrelInputController.swift in Sources */,

--- a/Squirrel.xcodeproj/project.pbxproj
+++ b/Squirrel.xcodeproj/project.pbxproj
@@ -38,6 +38,11 @@
 		44E98EC314AE1AC900847AD6 /* utf8.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 44E98EC214AE1AC900847AD6 /* utf8.cpp */; };
 		44F7708F152B3334005CF491 /* dsa_pub.pem in Resources */ = {isa = PBXBuildFile; fileRef = 44F7708E152B3334005CF491 /* dsa_pub.pem */; };
 		44F84AD714E94C490005D70B /* SquirrelPanel.m in Sources */ = {isa = PBXBuildFile; fileRef = 44F84AD614E94C490005D70B /* SquirrelPanel.m */; };
+		5B511EF428EEA3080019E25B /* SwiftExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B511EEA28EEA3080019E25B /* SwiftExtension.swift */; };
+		5B511EF628EEA3080019E25B /* CocoaExtension_NSEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B511EED28EEA3080019E25B /* CocoaExtension_NSEvent.swift */; };
+		5B511EF728EEA3080019E25B /* CocoaExtension_Misc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B511EEE28EEA3080019E25B /* CocoaExtension_Misc.swift */; };
+		5B511EF928EEA3080019E25B /* IMKHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B511EF128EEA3080019E25B /* IMKHelper.swift */; };
+		5B511EFA28EEA3080019E25B /* TISInputSourceExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B511EF228EEA3080019E25B /* TISInputSourceExtension.swift */; };
 		77AA68142588916F00A592E2 /* hk2s.json in Copy opencc Files */ = {isa = PBXBuildFile; fileRef = 77AA67E22588916300A592E2 /* hk2s.json */; };
 		77AA68152588916F00A592E2 /* HKVariants.ocd2 in Copy opencc Files */ = {isa = PBXBuildFile; fileRef = 77AA67DC2588916300A592E2 /* HKVariants.ocd2 */; };
 		77AA68162588916F00A592E2 /* HKVariantsRev.ocd2 in Copy opencc Files */ = {isa = PBXBuildFile; fileRef = 77AA67E02588916300A592E2 /* HKVariantsRev.ocd2 */; };
@@ -237,6 +242,14 @@
 		44F84AD614E94C490005D70B /* SquirrelPanel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SquirrelPanel.m; sourceTree = "<group>"; };
 		44FA4D891685997300116C1F /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		44FA4D8E16859B2900116C1F /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/Localizable.strings"; sourceTree = "<group>"; };
+		5B511EE928EEA3080019E25B /* LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
+		5B511EEA28EEA3080019E25B /* SwiftExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftExtension.swift; sourceTree = "<group>"; };
+		5B511EEC28EEA3080019E25B /* LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
+		5B511EED28EEA3080019E25B /* CocoaExtension_NSEvent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CocoaExtension_NSEvent.swift; sourceTree = "<group>"; };
+		5B511EEE28EEA3080019E25B /* CocoaExtension_Misc.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CocoaExtension_Misc.swift; sourceTree = "<group>"; };
+		5B511EF028EEA3080019E25B /* LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
+		5B511EF128EEA3080019E25B /* IMKHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IMKHelper.swift; sourceTree = "<group>"; };
+		5B511EF228EEA3080019E25B /* TISInputSourceExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TISInputSourceExtension.swift; sourceTree = "<group>"; };
 		77AA67DC2588916300A592E2 /* HKVariants.ocd2 */ = {isa = PBXFileReference; lastKnownFileType = file; path = HKVariants.ocd2; sourceTree = "<group>"; };
 		77AA67DD2588916300A592E2 /* t2s.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = t2s.json; sourceTree = "<group>"; };
 		77AA67DE2588916300A592E2 /* t2tw.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = t2tw.json; sourceTree = "<group>"; };
@@ -354,6 +367,7 @@
 		29B97314FDCFA39411CA2CEA /* Squirrel */ = {
 			isa = PBXGroup;
 			children = (
+				5B511EE528EEA2140019E25B /* 3rdParty */,
 				442C648F1F7A40180027EFBE /* bin */,
 				44DA7A4214DD598900C1ED3B /* SharedSupport */,
 				080E96DDFE201D6D7F000001 /* Sources */,
@@ -457,6 +471,53 @@
 			path = utf8;
 			sourceTree = "<group>";
 		};
+		5B511EE528EEA2140019E25B /* 3rdParty */ = {
+			isa = PBXGroup;
+			children = (
+				5B511EE628EEA2240019E25B /* vChewingProject */,
+			);
+			path = 3rdParty;
+			sourceTree = "<group>";
+		};
+		5B511EE628EEA2240019E25B /* vChewingProject */ = {
+			isa = PBXGroup;
+			children = (
+				5B511EEB28EEA3080019E25B /* CocoaExtension4RIME */,
+				5B511EEF28EEA3080019E25B /* IMKUtils4RIME */,
+				5B511EE828EEA3080019E25B /* SwiftExtension4RIME */,
+			);
+			path = vChewingProject;
+			sourceTree = "<group>";
+		};
+		5B511EE828EEA3080019E25B /* SwiftExtension4RIME */ = {
+			isa = PBXGroup;
+			children = (
+				5B511EE928EEA3080019E25B /* LICENSE */,
+				5B511EEA28EEA3080019E25B /* SwiftExtension.swift */,
+			);
+			path = SwiftExtension4RIME;
+			sourceTree = "<group>";
+		};
+		5B511EEB28EEA3080019E25B /* CocoaExtension4RIME */ = {
+			isa = PBXGroup;
+			children = (
+				5B511EEC28EEA3080019E25B /* LICENSE */,
+				5B511EED28EEA3080019E25B /* CocoaExtension_NSEvent.swift */,
+				5B511EEE28EEA3080019E25B /* CocoaExtension_Misc.swift */,
+			);
+			path = CocoaExtension4RIME;
+			sourceTree = "<group>";
+		};
+		5B511EEF28EEA3080019E25B /* IMKUtils4RIME */ = {
+			isa = PBXGroup;
+			children = (
+				5B511EF028EEA3080019E25B /* LICENSE */,
+				5B511EF128EEA3080019E25B /* IMKHelper.swift */,
+				5B511EF228EEA3080019E25B /* TISInputSourceExtension.swift */,
+			);
+			path = IMKUtils4RIME;
+			sourceTree = "<group>";
+		};
 		7B5488A71D2DAC9D0056A1BE /* plum */ = {
 			isa = PBXGroup;
 			children = (
@@ -520,7 +581,7 @@
 		29B97313FDCFA39411CA2CEA /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1220;
+				LastUpgradeCheck = 1400;
 			};
 			buildConfigurationList = C01FCF4E08A954540054247B /* Build configuration list for PBXProject "Squirrel" */;
 			compatibilityVersion = "Xcode 10.0";
@@ -569,10 +630,15 @@
 				7BDB21231C6EF1BE0025E351 /* SquirrelConfig.m in Sources */,
 				8D11072D0486CEB800E47090 /* main.m in Sources */,
 				A47C48DF105E8CE8006D528B /* macos_keycode.m in Sources */,
+				5B511EF928EEA3080019E25B /* IMKHelper.swift in Sources */,
+				5B511EF628EEA3080019E25B /* CocoaExtension_NSEvent.swift in Sources */,
 				44AC951A1430CF6000C888FB /* SquirrelApplicationDelegate.m in Sources */,
+				5B511EFA28EEA3080019E25B /* TISInputSourceExtension.swift in Sources */,
 				44AC951B1430CF6000C888FB /* SquirrelInputController.m in Sources */,
+				5B511EF428EEA3080019E25B /* SwiftExtension.swift in Sources */,
 				44E98EC314AE1AC900847AD6 /* utf8.cpp in Sources */,
 				4443A83A1828CC5100731305 /* input_source.m in Sources */,
+				5B511EF728EEA3080019E25B /* CocoaExtension_Misc.swift in Sources */,
 				44F84AD714E94C490005D70B /* SquirrelPanel.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -622,6 +688,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 0.15.2;
+				DEAD_CODE_STRIPPING = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(FRAMEWORK_SEARCH_PATHS_QUOTED_FOR_TARGET_1)",
@@ -668,6 +735,7 @@
 				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 0.15.2;
+				DEAD_CODE_STRIPPING = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(FRAMEWORK_SEARCH_PATHS_QUOTED_FOR_TARGET_1)",
@@ -725,9 +793,11 @@
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				DEAD_CODE_STRIPPING = YES;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -775,10 +845,12 @@
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/Release";
+				DEAD_CODE_STRIPPING = YES;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -801,6 +873,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
+				SWIFT_COMPILATION_MODE = wholemodule;
 			};
 			name = Release;
 		};

--- a/Squirrel.xcodeproj/project.pbxproj
+++ b/Squirrel.xcodeproj/project.pbxproj
@@ -38,11 +38,13 @@
 		44E98EC314AE1AC900847AD6 /* utf8.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 44E98EC214AE1AC900847AD6 /* utf8.cpp */; };
 		44F7708F152B3334005CF491 /* dsa_pub.pem in Resources */ = {isa = PBXBuildFile; fileRef = 44F7708E152B3334005CF491 /* dsa_pub.pem */; };
 		44F84AD714E94C490005D70B /* SquirrelPanel.m in Sources */ = {isa = PBXBuildFile; fileRef = 44F84AD614E94C490005D70B /* SquirrelPanel.m */; };
-		5B511EF428EEA3080019E25B /* SwiftExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B511EEA28EEA3080019E25B /* SwiftExtension.swift */; };
-		5B511EF628EEA3080019E25B /* CocoaExtension_NSEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B511EED28EEA3080019E25B /* CocoaExtension_NSEvent.swift */; };
-		5B511EF728EEA3080019E25B /* CocoaExtension_Misc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B511EEE28EEA3080019E25B /* CocoaExtension_Misc.swift */; };
-		5B511EF928EEA3080019E25B /* IMKHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B511EF128EEA3080019E25B /* IMKHelper.swift */; };
-		5B511EFA28EEA3080019E25B /* TISInputSourceExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B511EF228EEA3080019E25B /* TISInputSourceExtension.swift */; };
+		5B511F1C28EEC25D0019E25B /* SquirrelInputController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B511F1B28EEC25D0019E25B /* SquirrelInputController.swift */; };
+		5B511F2928EEC27A0019E25B /* CocoaExtension_NSEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B511F1F28EEC27A0019E25B /* CocoaExtension_NSEvent.swift */; };
+		5B511F2A28EEC27A0019E25B /* CocoaExtension_Misc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B511F2028EEC27A0019E25B /* CocoaExtension_Misc.swift */; };
+		5B511F2C28EEC27A0019E25B /* SwiftExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B511F2328EEC27A0019E25B /* SwiftExtension.swift */; };
+		5B511F2E28EEC27A0019E25B /* IMKHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B511F2628EEC27A0019E25B /* IMKHelper.swift */; };
+		5B511F2F28EEC27A0019E25B /* TISInputSourceExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B511F2728EEC27A0019E25B /* TISInputSourceExtension.swift */; };
+		5BA2241228EECC5C004DCA14 /* SquirrelInputController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA2241128EECC5C004DCA14 /* SquirrelInputController.swift */; };
 		77AA68142588916F00A592E2 /* hk2s.json in Copy opencc Files */ = {isa = PBXBuildFile; fileRef = 77AA67E22588916300A592E2 /* hk2s.json */; };
 		77AA68152588916F00A592E2 /* HKVariants.ocd2 in Copy opencc Files */ = {isa = PBXBuildFile; fileRef = 77AA67DC2588916300A592E2 /* HKVariants.ocd2 */; };
 		77AA68162588916F00A592E2 /* HKVariantsRev.ocd2 in Copy opencc Files */ = {isa = PBXBuildFile; fileRef = 77AA67E02588916300A592E2 /* HKVariantsRev.ocd2 */; };
@@ -242,14 +244,17 @@
 		44F84AD614E94C490005D70B /* SquirrelPanel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SquirrelPanel.m; sourceTree = "<group>"; };
 		44FA4D891685997300116C1F /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		44FA4D8E16859B2900116C1F /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/Localizable.strings"; sourceTree = "<group>"; };
-		5B511EE928EEA3080019E25B /* LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
-		5B511EEA28EEA3080019E25B /* SwiftExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftExtension.swift; sourceTree = "<group>"; };
-		5B511EEC28EEA3080019E25B /* LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
-		5B511EED28EEA3080019E25B /* CocoaExtension_NSEvent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CocoaExtension_NSEvent.swift; sourceTree = "<group>"; };
-		5B511EEE28EEA3080019E25B /* CocoaExtension_Misc.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CocoaExtension_Misc.swift; sourceTree = "<group>"; };
-		5B511EF028EEA3080019E25B /* LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
-		5B511EF128EEA3080019E25B /* IMKHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IMKHelper.swift; sourceTree = "<group>"; };
-		5B511EF228EEA3080019E25B /* TISInputSourceExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TISInputSourceExtension.swift; sourceTree = "<group>"; };
+		5B511F1A28EEC25D0019E25B /* Squirrel-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Squirrel-Bridging-Header.h"; sourceTree = "<group>"; };
+		5B511F1B28EEC25D0019E25B /* SquirrelInputController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SquirrelInputController.swift; sourceTree = "<group>"; };
+		5B511F1E28EEC27A0019E25B /* LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
+		5B511F1F28EEC27A0019E25B /* CocoaExtension_NSEvent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CocoaExtension_NSEvent.swift; sourceTree = "<group>"; };
+		5B511F2028EEC27A0019E25B /* CocoaExtension_Misc.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CocoaExtension_Misc.swift; sourceTree = "<group>"; };
+		5B511F2228EEC27A0019E25B /* LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
+		5B511F2328EEC27A0019E25B /* SwiftExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftExtension.swift; sourceTree = "<group>"; };
+		5B511F2528EEC27A0019E25B /* LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
+		5B511F2628EEC27A0019E25B /* IMKHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IMKHelper.swift; sourceTree = "<group>"; };
+		5B511F2728EEC27A0019E25B /* TISInputSourceExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TISInputSourceExtension.swift; sourceTree = "<group>"; };
+		5BA2241128EECC5C004DCA14 /* SquirrelInputController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SquirrelInputController.swift; sourceTree = "<group>"; };
 		77AA67DC2588916300A592E2 /* HKVariants.ocd2 */ = {isa = PBXFileReference; lastKnownFileType = file; path = HKVariants.ocd2; sourceTree = "<group>"; };
 		77AA67DD2588916300A592E2 /* t2s.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = t2s.json; sourceTree = "<group>"; };
 		77AA67DE2588916300A592E2 /* t2tw.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = t2tw.json; sourceTree = "<group>"; };
@@ -320,6 +325,7 @@
 				44AC95171430CF6000C888FB /* SquirrelApplicationDelegate.m */,
 				44AC95181430CF6000C888FB /* SquirrelInputController.h */,
 				44AC95191430CF6000C888FB /* SquirrelInputController.m */,
+				5BA2241128EECC5C004DCA14 /* SquirrelInputController.swift */,
 				A47C48DE105E8CE8006D528B /* macos_keycode.m */,
 				A44571AB0DBF42C200F793F9 /* macos_keycode.h */,
 				32CA4F630368D1EE00C91783 /* Squirrel_Prefix.pch */,
@@ -367,6 +373,7 @@
 		29B97314FDCFA39411CA2CEA /* Squirrel */ = {
 			isa = PBXGroup;
 			children = (
+				5B511F1B28EEC25D0019E25B /* SquirrelInputController.swift */,
 				5B511EE528EEA2140019E25B /* 3rdParty */,
 				442C648F1F7A40180027EFBE /* bin */,
 				44DA7A4214DD598900C1ED3B /* SharedSupport */,
@@ -374,6 +381,7 @@
 				29B97317FDCFA39411CA2CEA /* Resources */,
 				29B97323FDCFA39411CA2CEA /* Frameworks */,
 				19C28FACFE9D520D11CA2CBB /* Products */,
+				5B511F1A28EEC25D0019E25B /* Squirrel-Bridging-Header.h */,
 			);
 			indentWidth = 2;
 			name = Squirrel;
@@ -482,38 +490,38 @@
 		5B511EE628EEA2240019E25B /* vChewingProject */ = {
 			isa = PBXGroup;
 			children = (
-				5B511EEB28EEA3080019E25B /* CocoaExtension4RIME */,
-				5B511EEF28EEA3080019E25B /* IMKUtils4RIME */,
-				5B511EE828EEA3080019E25B /* SwiftExtension4RIME */,
+				5B511F1D28EEC27A0019E25B /* CocoaExtension4RIME */,
+				5B511F2428EEC27A0019E25B /* IMKUtils4RIME */,
+				5B511F2128EEC27A0019E25B /* SwiftExtension4RIME */,
 			);
 			path = vChewingProject;
 			sourceTree = "<group>";
 		};
-		5B511EE828EEA3080019E25B /* SwiftExtension4RIME */ = {
+		5B511F1D28EEC27A0019E25B /* CocoaExtension4RIME */ = {
 			isa = PBXGroup;
 			children = (
-				5B511EE928EEA3080019E25B /* LICENSE */,
-				5B511EEA28EEA3080019E25B /* SwiftExtension.swift */,
-			);
-			path = SwiftExtension4RIME;
-			sourceTree = "<group>";
-		};
-		5B511EEB28EEA3080019E25B /* CocoaExtension4RIME */ = {
-			isa = PBXGroup;
-			children = (
-				5B511EEC28EEA3080019E25B /* LICENSE */,
-				5B511EED28EEA3080019E25B /* CocoaExtension_NSEvent.swift */,
-				5B511EEE28EEA3080019E25B /* CocoaExtension_Misc.swift */,
+				5B511F1E28EEC27A0019E25B /* LICENSE */,
+				5B511F1F28EEC27A0019E25B /* CocoaExtension_NSEvent.swift */,
+				5B511F2028EEC27A0019E25B /* CocoaExtension_Misc.swift */,
 			);
 			path = CocoaExtension4RIME;
 			sourceTree = "<group>";
 		};
-		5B511EEF28EEA3080019E25B /* IMKUtils4RIME */ = {
+		5B511F2128EEC27A0019E25B /* SwiftExtension4RIME */ = {
 			isa = PBXGroup;
 			children = (
-				5B511EF028EEA3080019E25B /* LICENSE */,
-				5B511EF128EEA3080019E25B /* IMKHelper.swift */,
-				5B511EF228EEA3080019E25B /* TISInputSourceExtension.swift */,
+				5B511F2228EEC27A0019E25B /* LICENSE */,
+				5B511F2328EEC27A0019E25B /* SwiftExtension.swift */,
+			);
+			path = SwiftExtension4RIME;
+			sourceTree = "<group>";
+		};
+		5B511F2428EEC27A0019E25B /* IMKUtils4RIME */ = {
+			isa = PBXGroup;
+			children = (
+				5B511F2528EEC27A0019E25B /* LICENSE */,
+				5B511F2628EEC27A0019E25B /* IMKHelper.swift */,
+				5B511F2728EEC27A0019E25B /* TISInputSourceExtension.swift */,
 			);
 			path = IMKUtils4RIME;
 			sourceTree = "<group>";
@@ -582,6 +590,11 @@
 			isa = PBXProject;
 			attributes = {
 				LastUpgradeCheck = 1400;
+				TargetAttributes = {
+					8D1107260486CEB800E47090 = {
+						LastSwiftMigration = 1400;
+					};
+				};
 			};
 			buildConfigurationList = C01FCF4E08A954540054247B /* Build configuration list for PBXProject "Squirrel" */;
 			compatibilityVersion = "Xcode 10.0";
@@ -630,16 +643,18 @@
 				7BDB21231C6EF1BE0025E351 /* SquirrelConfig.m in Sources */,
 				8D11072D0486CEB800E47090 /* main.m in Sources */,
 				A47C48DF105E8CE8006D528B /* macos_keycode.m in Sources */,
-				5B511EF928EEA3080019E25B /* IMKHelper.swift in Sources */,
-				5B511EF628EEA3080019E25B /* CocoaExtension_NSEvent.swift in Sources */,
+				5B511F2928EEC27A0019E25B /* CocoaExtension_NSEvent.swift in Sources */,
 				44AC951A1430CF6000C888FB /* SquirrelApplicationDelegate.m in Sources */,
-				5B511EFA28EEA3080019E25B /* TISInputSourceExtension.swift in Sources */,
+				5B511F2C28EEC27A0019E25B /* SwiftExtension.swift in Sources */,
 				44AC951B1430CF6000C888FB /* SquirrelInputController.m in Sources */,
-				5B511EF428EEA3080019E25B /* SwiftExtension.swift in Sources */,
 				44E98EC314AE1AC900847AD6 /* utf8.cpp in Sources */,
+				5B511F1C28EEC25D0019E25B /* SquirrelInputController.swift in Sources */,
 				4443A83A1828CC5100731305 /* input_source.m in Sources */,
-				5B511EF728EEA3080019E25B /* CocoaExtension_Misc.swift in Sources */,
+				5B511F2F28EEC27A0019E25B /* TISInputSourceExtension.swift in Sources */,
+				5B511F2A28EEC27A0019E25B /* CocoaExtension_Misc.swift in Sources */,
+				5BA2241228EECC5C004DCA14 /* SquirrelInputController.swift in Sources */,
 				44F84AD714E94C490005D70B /* SquirrelPanel.m in Sources */,
+				5B511F2E28EEC27A0019E25B /* IMKHelper.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -683,6 +698,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
@@ -723,6 +739,9 @@
 				PRODUCT_BUNDLE_IDENTIFIER = im.rime.inputmethod.Squirrel;
 				PRODUCT_NAME = Squirrel;
 				SDKROOT = macosx;
+				SWIFT_OBJC_BRIDGING_HEADER = "Squirrel-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
 				WRAPPER_EXTENSION = app;
 			};
 			name = Debug;
@@ -731,6 +750,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
@@ -769,6 +789,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = im.rime.inputmethod.Squirrel;
 				PRODUCT_NAME = Squirrel;
 				SDKROOT = macosx;
+				SWIFT_OBJC_BRIDGING_HEADER = "Squirrel-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
 				WRAPPER_EXTENSION = app;
 			};
 			name = Release;

--- a/Squirrel.xcodeproj/xcshareddata/xcschemes/Squirrel.xcscheme
+++ b/Squirrel.xcodeproj/xcshareddata/xcschemes/Squirrel.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1400"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8D1107260486CEB800E47090"
+               BuildableName = "Squirrel.app"
+               BlueprintName = "Squirrel"
+               ReferencedContainer = "container:Squirrel.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8D1107260486CEB800E47090"
+            BuildableName = "Squirrel.app"
+            BlueprintName = "Squirrel"
+            ReferencedContainer = "container:Squirrel.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8D1107260486CEB800E47090"
+            BuildableName = "Squirrel.app"
+            BlueprintName = "Squirrel"
+            ReferencedContainer = "container:Squirrel.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/SquirrelApplicationDelegate.m
+++ b/SquirrelApplicationDelegate.m
@@ -1,6 +1,7 @@
 #import "SquirrelApplicationDelegate.h"
 
 #import <rime_api.h>
+#import "Squirrel-Swift.h"
 #import "SquirrelConfig.h"
 #import "SquirrelPanel.h"
 
@@ -25,6 +26,7 @@ static NSString *const kRimeWikiURL = @"https://github.com/rime/home/wiki";
 -(IBAction)configure:(id)sender
 {
   [[NSWorkspace sharedWorkspace] openFile:(@"~/Library/Rime").stringByStandardizingPath];
+  [SquirrelSettingsWindow show];
 }
 
 -(IBAction)openWiki:(id)sender

--- a/SquirrelInputController.m
+++ b/SquirrelInputController.m
@@ -271,10 +271,22 @@ const int N_KEY_ROLL_OVER = 50;
 
 -(void)activateServer:(id)sender
 {
-  //NSLog(@"activateServer:");
-  if ([NSApp.squirrelAppDelegate.config getBool:@"us_keyboard_layout"]) {
-    [sender overrideKeyboardWithKeyboardNamed:@"com.apple.keylayout.US"];
+  // activateServer() 與 setValue() 是組合拳，前者執行之後必定會立刻執行後者。
+  // 所以千萬不要讓前者做後者會做的事情，否則很容易會出現重複計算、乃至迴圈計算。
+  // 同一個客體應用之間切換輸入法的時候，可能會出現僅觸發 setValue 的情況。
+}
+
+- (void)setValue:(id)value forTag:(long)tag client:(id)sender
+{
+  //NSLog(@"setValue:");
+
+  // 以防萬一：讓 setValue 的行為僅對自身起作用。
+  if ([value isKindOfClass:[NSString class]] && [value containsString: [NSBundle mainBundle].bundleIdentifier]) {
+    if ([NSApp.squirrelAppDelegate.config getBool:@"us_keyboard_layout"]) {
+      [self overrideKeyboard];
+    }
   }
+
   _preeditString = @"";
 }
 

--- a/SquirrelInputController.m
+++ b/SquirrelInputController.m
@@ -1,5 +1,6 @@
 #import "SquirrelInputController.h"
 
+#import "Squirrel-Swift.h"
 #import "SquirrelApplicationDelegate.h"
 #import "SquirrelConfig.h"
 #import "SquirrelPanel.h"

--- a/SquirrelInputController.m
+++ b/SquirrelInputController.m
@@ -271,23 +271,13 @@ const int N_KEY_ROLL_OVER = 50;
 
 -(void)activateServer:(id)sender
 {
-  // activateServer() 與 setValue() 是組合拳，前者執行之後必定會立刻執行後者。
-  // 所以千萬不要讓前者做後者會做的事情，否則很容易會出現重複計算、乃至迴圈計算。
-  // 同一個客體應用之間切換輸入法的時候，可能會出現僅觸發 setValue 的情況。
+  //NSLog(@"activateServer:");
+  [self overrideKeyboard];
+  _preeditString = @"";
 }
 
 - (void)setValue:(id)value forTag:(long)tag client:(id)sender
 {
-  //NSLog(@"setValue:");
-
-  // 以防萬一：讓 setValue 的行為僅對自身起作用。
-  if ([value isKindOfClass:[NSString class]] && [value containsString: [NSBundle mainBundle].bundleIdentifier]) {
-    if ([NSApp.squirrelAppDelegate.config getBool:@"us_keyboard_layout"]) {
-      [self overrideKeyboard];
-    }
-  }
-
-  _preeditString = @"";
 }
 
 -(instancetype)initWithServer:(IMKServer*)server delegate:(id)delegate client:(id)inputClient
@@ -297,6 +287,8 @@ const int N_KEY_ROLL_OVER = 50;
     _currentClient = inputClient;
     [self createSession];
   }
+  [self registerSessionControllerIntoSet];
+
   return self;
 }
 
@@ -372,6 +364,7 @@ const int N_KEY_ROLL_OVER = 50;
 
 -(void)dealloc
 {
+  [self removeSessionControllerFromSet];
   [self destroySession];
 }
 

--- a/SquirrelInputController.swift
+++ b/SquirrelInputController.swift
@@ -1,0 +1,1 @@
+import Foundation

--- a/SquirrelInputController.swift
+++ b/SquirrelInputController.swift
@@ -1,1 +1,13 @@
 import Foundation
+
+@objc public extension SquirrelInputController { static var basicKeyboardLayoutNameVerified: String {
+  let result = Properties.shared.basicKeyboardLayout
+  return (TISInputSource.generate(from: result) != nil) ? result : "com.apple.keylayout.ABC"
+}
+
+func overrideKeyboard() {
+  DispatchQueue.main.async { [self] in
+    self.client()?.overrideKeyboard(withKeyboardNamed: Self.basicKeyboardLayoutNameVerified)
+  }
+}
+}

--- a/SquirrelInputController.swift
+++ b/SquirrelInputController.swift
@@ -1,13 +1,30 @@
 import Foundation
 
-@objc public extension SquirrelInputController { static var basicKeyboardLayoutNameVerified: String {
-  let result = Properties.shared.basicKeyboardLayout
-  return (TISInputSource.generate(from: result) != nil) ? result : "com.apple.keylayout.ABC"
-}
+public var sessionControllers: Set<SquirrelInputController> = .init()
 
-func overrideKeyboard() {
-  DispatchQueue.main.async { [self] in
-    self.client()?.overrideKeyboard(withKeyboardNamed: Self.basicKeyboardLayoutNameVerified)
+@objc public extension SquirrelInputController {
+  static var isBasicKeyboardLayoutDefinedValidInPlist: Bool {
+    TISInputSource.generate(from: Properties.shared.basicKeyboardLayout) != nil
   }
-}
+
+  static var basicKeyboardLayoutNameVerified: String? {
+    let result = Properties.shared.basicKeyboardLayout
+    return (TISInputSource.generate(from: result) != nil) ? result : nil
+  }
+
+  func overrideKeyboard() {
+    DispatchQueue.main.async { [self] in
+      if let verified = Self.basicKeyboardLayoutNameVerified {
+        client()?.overrideKeyboard(withKeyboardNamed: verified)
+      }
+    }
+  }
+
+  func registerSessionControllerIntoSet() {
+    sessionControllers.insert(self)
+  }
+
+  func removeSessionControllerFromSet() {
+    sessionControllers.remove(self)
+  }
 }

--- a/SquirrelSettingsWindow.swift
+++ b/SquirrelSettingsWindow.swift
@@ -1,0 +1,62 @@
+import Cocoa
+
+@objc class SquirrelSettingsWindow: NSWindowController {
+  @IBOutlet var basicKeyboardLayoutButton: NSPopUpButton!
+  @IBOutlet var theWindow: NSWindow!
+
+  @objc static var shared: SquirrelSettingsWindow?
+
+  override func windowDidLoad() {
+    super.windowDidLoad()
+    window = theWindow
+    initiateKeyLayoutDropdownButton()
+  }
+
+  @objc static func show() {
+    if shared == nil {
+      shared = .init(windowNibName: "SquirrelSettingsWindow")
+    }
+    guard let shared = shared else { return }
+    shared.window?.center()
+    shared.window?.orderFrontRegardless() // 逼著屬性視窗往最前方顯示
+    shared.window?.level = .statusBar
+    if #available(macOS 10.10, *) {
+      shared.window?.titlebarAppearsTransparent = true
+    }
+    NSApp.setActivationPolicy(.accessory)
+    NSApp.activate(ignoringOtherApps: true)
+  }
+}
+
+extension SquirrelSettingsWindow {
+  func initiateKeyLayoutDropdownButton() {
+    var usKeyboardLayoutItem: NSMenuItem?
+    var chosenBaseKeyboardLayoutItem: NSMenuItem?
+    basicKeyboardLayoutButton.menu?.removeAllItems()
+    let basicKeyboardLayoutID = Properties.shared.basicKeyboardLayout
+
+    for source in IMKHelper.allowedBasicLayoutsAsTISInputSources {
+      guard let source = source else {
+        basicKeyboardLayoutButton.menu?.addItem(NSMenuItem.separator())
+        continue
+      }
+      let menuItem = NSMenuItem()
+      menuItem.title = source.vChewingLocalizedName
+      menuItem.representedObject = source.identifier
+      if source.identifier == "com.apple.keylayout.US" { usKeyboardLayoutItem = menuItem }
+      if basicKeyboardLayoutID == source.identifier { chosenBaseKeyboardLayoutItem = menuItem }
+      basicKeyboardLayoutButton.menu?.addItem(menuItem)
+    }
+
+    basicKeyboardLayoutButton.select(chosenBaseKeyboardLayoutItem ?? usKeyboardLayoutItem)
+  }
+
+  @IBAction func updateBasicKeyboardLayoutAction(_: Any) {
+    if let sourceID = basicKeyboardLayoutButton.selectedItem?.representedObject as? String {
+      Properties.shared.basicKeyboardLayout = sourceID
+      sessionControllers.forEach {
+        $0.overrideKeyboard()
+      }
+    }
+  }
+}

--- a/SquirrelSettingsWindow.swift
+++ b/SquirrelSettingsWindow.swift
@@ -41,7 +41,7 @@ extension SquirrelSettingsWindow {
         continue
       }
       let menuItem = NSMenuItem()
-      menuItem.title = source.vChewingLocalizedName
+      menuItem.title = source.localizedName
       menuItem.representedObject = source.identifier
       if source.identifier == "com.apple.keylayout.US" { usKeyboardLayoutItem = menuItem }
       if basicKeyboardLayoutID == source.identifier { chosenBaseKeyboardLayoutItem = menuItem }

--- a/SquirrelSettingsWindow.xib
+++ b/SquirrelSettingsWindow.xib
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21225" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+    <dependencies>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21225"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <customObject id="-2" userLabel="File's Owner" customClass="SquirrelSettingsWindow" customModule="Squirrel" customModuleProvider="target">
+            <connections>
+                <outlet property="basicKeyboardLayoutButton" destination="SAs-ky-Hj4" id="Cm4-11-q9O"/>
+                <outlet property="theWindow" destination="F0z-JX-Cv5" id="Y9w-af-H2Y"/>
+            </connections>
+        </customObject>
+        <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
+        <customObject id="-3" userLabel="Application" customClass="NSObject"/>
+        <window title="Squirrel Settings" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" titlebarAppearsTransparent="YES" id="F0z-JX-Cv5" userLabel="SquirrelSettingsWindow">
+            <windowStyleMask key="styleMask" titled="YES" closable="YES" fullSizeContentView="YES"/>
+            <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
+            <rect key="contentRect" x="196" y="240" width="381" height="82"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="875"/>
+            <view key="contentView" id="se5-gp-TjO">
+                <rect key="frame" x="0.0" y="0.0" width="381" height="82"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <stackView distribution="fill" orientation="horizontal" alignment="top" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" fixedFrame="YES" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="icc-tr-Rcw">
+                        <rect key="frame" x="20" y="20" width="330" height="20"/>
+                        <subviews>
+                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1E1-vm-e4q">
+                                <rect key="frame" x="-2" y="4" width="71" height="16"/>
+                                <textFieldCell key="cell" lineBreakMode="clipping" title="KeyLayout:" id="5TS-Z1-9jq">
+                                    <font key="font" metaFont="system"/>
+                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                            <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="SAs-ky-Hj4">
+                                <rect key="frame" x="72" y="-4" width="262" height="25"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="255" id="rSG-jt-qHe"/>
+                                </constraints>
+                                <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" id="EYT-Eu-Ij3">
+                                    <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
+                                    <font key="font" metaFont="menu"/>
+                                    <menu key="menu" id="EN3-AD-X99"/>
+                                </popUpButtonCell>
+                                <connections>
+                                    <action selector="updateBasicKeyboardLayoutAction:" target="-2" id="omK-oP-bLn"/>
+                                </connections>
+                            </popUpButton>
+                        </subviews>
+                        <visibilityPriorities>
+                            <integer value="1000"/>
+                            <integer value="1000"/>
+                        </visibilityPriorities>
+                        <customSpacing>
+                            <real value="3.4028234663852886e+38"/>
+                            <real value="3.4028234663852886e+38"/>
+                        </customSpacing>
+                    </stackView>
+                </subviews>
+            </view>
+            <point key="canvasLocation" x="-1.5" y="16"/>
+        </window>
+    </objects>
+</document>

--- a/en.lproj/SquirrelSettingsWindow.strings
+++ b/en.lproj/SquirrelSettingsWindow.strings
@@ -1,0 +1,6 @@
+
+/* Class = "NSTextFieldCell"; title = "KeyLayout:"; ObjectID = "5TS-Z1-9jq"; */
+"5TS-Z1-9jq.title" = "KeyLayout:";
+
+/* Class = "NSWindow"; title = "Squirrel Settings"; ObjectID = "F0z-JX-Cv5"; */
+"F0z-JX-Cv5.title" = "Squirrel Settings";

--- a/zh-Hans.lproj/SquirrelSettingsWindow.strings
+++ b/zh-Hans.lproj/SquirrelSettingsWindow.strings
@@ -1,0 +1,6 @@
+
+/* Class = "NSTextFieldCell"; title = "KeyLayout:"; ObjectID = "5TS-Z1-9jq"; */
+"5TS-Z1-9jq.title" = "键盘布局:";
+
+/* Class = "NSWindow"; title = "Squirrel Settings"; ObjectID = "F0z-JX-Cv5"; */
+"F0z-JX-Cv5.title" = "鼠须管设置";

--- a/zh-Hant.lproj/SquirrelSettingsWindow.strings
+++ b/zh-Hant.lproj/SquirrelSettingsWindow.strings
@@ -1,0 +1,6 @@
+
+/* Class = "NSTextFieldCell"; title = "KeyLayout:"; ObjectID = "5TS-Z1-9jq"; */
+"5TS-Z1-9jq.title" = "鍵盤佈局:";
+
+/* Class = "NSWindow"; title = "Squirrel Settings"; ObjectID = "F0z-JX-Cv5"; */
+"F0z-JX-Cv5.title" = "鼠鬚管設定";


### PR DESCRIPTION
Squirrel 迄今为止仅允许在输入法配置档案里面决定是否启用 US 布局强制覆写。这样对依赖于 Colemak / Dvorak 这类异种布局输入拼音的使用者们并不友好。这个 PR 旨在允许使用者们定义这个功能。

需要指定為 Colemak 鍵盤的話，跑终端指令：
```
defaults write im.rime.inputmethod.Squirrel BasicKeyboardLayout -string "com.apple.keylayout.Colemak"
```
需要指定為美規鍵盤的話：
```
defaults write im.rime.inputmethod.Squirrel BasicKeyboardLayout -string "com.apple.keylayout.ABC"
```
这次 PR 推送的内容也会检查终端指令输入的 keyLayout 参数值的合法性。

P.S.: 这个 PR 会使得 RIME 在建置时内捆 Swift Runtime，建置出来的 App 会肥一些（不到 50MB）。但尚未牺牲对 macOS 10.09-10.12.x 的支援。

P.P.S.: GUI 交互介面尚未实作。这个可能得需要与佛振等 maintainers 讨论之後以別的 PR 來完成。