### PR TITLE
Allow customisation of default keyboard layout

### DIFF
--- a/SquirrelInputController.m
+++ b/SquirrelInputController.m
@@ -271,8 +271,16 @@ const int N_KEY_ROLL_OVER = 50;
 -(void)activateServer:(id)sender
 {
   //NSLog(@"activateServer:");
-  if ([NSApp.squirrelAppDelegate.config getBool:@"us_keyboard_layout"]) {
-    [sender overrideKeyboardWithKeyboardNamed:@"com.apple.keylayout.US"];
+  NSString *keyboardLayout = [NSApp.squirrelAppDelegate.config getString:@"keyboard_layout"];
+  if ([keyboardLayout isEqualToString:@"last"] || [keyboardLayout isEqualToString:@""]) {
+    keyboardLayout = NULL;
+  } else if ([keyboardLayout isEqualToString:@"default"]) {
+    keyboardLayout = @"com.apple.keylayout.ABC";
+  } else if (![keyboardLayout hasPrefix:@"com.apple.keylayout."]) {
+    keyboardLayout = [NSString stringWithFormat:@"com.apple.keylayout.%@", keyboardLayout];
+  }
+  if (keyboardLayout) {
+    [sender overrideKeyboardWithKeyboardNamed:keyboardLayout];
   }
   _preeditString = @"";
 }

--- a/data/squirrel.yaml
+++ b/data/squirrel.yaml
@@ -3,7 +3,11 @@
 
 config_version: '0.37'
 
-us_keyboard_layout: false
+# options: last | default | _custom_
+# last: the last used latin keyboard layout
+# default: US (ABC) keyboard layout
+# _custom_: keyboard layout of your choice, e.g. 'com.apple.keylayout.USExtended'
+keyboard_layout: default
 
 # for veteran chord-typist
 chord_duration: 0.1  # seconds

--- a/data/squirrel.yaml
+++ b/data/squirrel.yaml
@@ -6,7 +6,7 @@ config_version: '0.37'
 # options: last | default | _custom_
 # last: the last used latin keyboard layout
 # default: US (ABC) keyboard layout
-# _custom_: keyboard layout of your choice, e.g. 'com.apple.keylayout.USExtended'
+# _custom_: keyboard layout of your choice, e.g. 'com.apple.keylayout.USExtended' or simply 'USExtended'
 keyboard_layout: default
 
 # for veteran chord-typist


### PR DESCRIPTION
Change the name of US keyboard layout to the updated one (`com.apple.keylayout.ABC`) and further allow user to set default keyboard layout other than `ABC` such as `US-Extended`, which allows accented Latin characters (e.g. typing `⌥`+`u` to get `ü`, partially fixes #646 )