### PR TITLE
prevent commit keystroke being hijacked

### DIFF
--- a/SquirrelConfig.h
+++ b/SquirrelConfig.h
@@ -17,7 +17,7 @@ typedef NSMutableDictionary<NSString *, NSNumber *> SquirrelMutableAppOptions;
 - (BOOL)hasSection:(NSString *)section;
 
 - (BOOL)getBool:(NSString *)option;
-- (NSInteger)getInt:(NSString *)option;
+- (int)getInt:(NSString *)option;
 - (double)getDouble:(NSString *)option;
 - (NSNumber *)getOptionalBool:(NSString *)option;
 - (NSNumber *)getOptionalInt:(NSString *)option;

--- a/SquirrelConfig.m
+++ b/SquirrelConfig.m
@@ -67,8 +67,8 @@
   return [self getOptionalBool:option].boolValue;
 }
 
-- (NSInteger)getInt:(NSString *)option {
-  return [self getOptionalInt:option].integerValue;
+- (int)getInt:(NSString *)option {
+  return [self getOptionalInt:option].intValue;
 }
 
 - (double)getDouble:(NSString *)option {
@@ -82,7 +82,7 @@
   }
   Bool value;
   if (_isOpen && rime_get_api()->config_get_bool(&_config, option.UTF8String, &value)) {
-    return _cache[option] = @(!!value);
+    return _cache[option] = [NSNumber numberWithBool:(BOOL)value];
   }
   return [_baseConfig getOptionalBool:option];
 }
@@ -94,7 +94,7 @@
   }
   int value;
   if (_isOpen && rime_get_api()->config_get_int(&_config, option.UTF8String, &value)) {
-    return _cache[option] = @(value);
+    return _cache[option] = [NSNumber numberWithInt:value];
   }
   return [_baseConfig getOptionalInt:option];
 
@@ -107,7 +107,7 @@
   }
   double value;
   if (_isOpen && rime_get_api()->config_get_double(&_config, option.UTF8String, &value)) {
-    return _cache[option] = @(value);
+    return _cache[option] = [NSNumber numberWithDouble:value];
   }
   return [_baseConfig getOptionalDouble:option];
 }
@@ -145,8 +145,12 @@
   rime_get_api()->config_begin_map(&iterator, &_config, rootKey.UTF8String);
   while (rime_get_api()->config_next(&iterator)) {
     //NSLog(@"DEBUG option[%d]: %s (%s)", iterator.index, iterator.key, iterator.path);
-    BOOL value = [self getBool:@(iterator.path)];
-    appOptions[@(iterator.key)] = @(value);
+    NSNumber *value = [self getOptionalBool:@(iterator.path)] ? :
+                      [self getOptionalInt:@(iterator.path)] ? :
+                      [self getOptionalDouble:@(iterator.path)];
+    if (value) {
+      appOptions[@(iterator.key)] = value;
+    }
   }
   rime_get_api()->config_end(&iterator);
   return [appOptions copy];

--- a/data/squirrel.yaml
+++ b/data/squirrel.yaml
@@ -341,6 +341,7 @@ app_options:
   com.apple.Terminal:
     ascii_mode: true
     no_inline: true
+    inline_placeholder: true
   com.googlecode.iterm2:
     ascii_mode: true
     no_inline: true
@@ -350,6 +351,7 @@ app_options:
     vim_mode: true    # 退出VIM插入模式自動切換輸入法狀態
   com.apple.dt.Xcode:
     ascii_mode: true
+    no_inline: true
   com.barebones.textwrangler:
     ascii_mode: true
   com.macromates.TextMate.preview:
@@ -367,9 +369,15 @@ app_options:
     no_inline: true
   co.zeit.hyper:
     ascii_mode: true
+  org.alacritty:
+    ascii_mode: true
+    vim_mode: true
+    panelless_commit_fix: true
+    inline_offset: -10
   com.google.Chrome:
     # 規避 https://github.com/rime/squirrel/issues/435
     inline: true
+    inline_placeholder: true
   ru.keepcoder.Telegram:
     # 規避 https://github.com/rime/squirrel/issues/475
     inline: true


### PR DESCRIPTION
By adding a placeholder before direct (panel-less) commits, keystroke hijacking is prevented.  resolves #741 

- Settings: Add `panelless_commit_fix: true` under `app_options/org.alacritty`

This pull also resolves similar issues (backspace being hijacked in the address bar of chrome): resolves #435 #450 #514  etc.

- Settings: Add `inline_placeholder: true` under `app_options/com.google.Chrome` and `app_options/com.operasoftware.Opera`

Furthermore, non-inline mode now works perfectly fine in terminal without even the need to have a space as placeholder (and this is the case for most apps except for a small handful e.g. chrome)