### PR TITLE
支持命令行切换中英文模式

### DIFF
--- a/SquirrelApplicationDelegate.m
+++ b/SquirrelApplicationDelegate.m
@@ -1,4 +1,5 @@
 #import "SquirrelApplicationDelegate.h"
+#include <Foundation/Foundation.h>
 
 #import <rime_api.h>
 #import "SquirrelConfig.h"
@@ -20,6 +21,12 @@ static NSString *const kRimeWikiURL = @"https://github.com/rime/home/wiki";
 {
   NSLog(@"Sync user data");
   rime_get_api()->sync_user_data();
+}
+
+-(void)userChange:(NSDictionary *)args
+{
+  NSLog(@"Sync user data");
+  [_panel changeToAscii:args];
 }
 
 -(IBAction)configure:(id)sender
@@ -214,6 +221,17 @@ void notification_handler(void* context_object, RimeSessionId session_id,
   [self syncUserData:nil];
 }
 
+-(void)rimeNeedsChange:(NSNotification *)aNotification
+{
+  NSLog(@"Sync rime on demand.");
+  [self userChange:aNotification.userInfo];
+}
+
+-(void)rimeNeedsPrev:(NSNotification *)aNotification
+{
+   [_panel changeToPrev];
+}
+
 -(NSApplicationTerminateReply)applicationShouldTerminate:(NSApplication *)sender
 {
   NSLog(@"Squirrel is quitting.");
@@ -241,6 +259,14 @@ void notification_handler(void* context_object, RimeSessionId session_id,
   [notifCenter addObserver:self
                   selector:@selector(rimeNeedsSync:)
                       name:@"SquirrelSyncNotification"
+                    object:nil];
+  [notifCenter addObserver:self
+                  selector:@selector(rimeNeedsChange:)
+                      name:@"SquirrelChangeNotification"
+                    object:nil];
+  [notifCenter addObserver:self
+                  selector:@selector(rimeNeedsPrev:)
+                      name:@"SquirrelChangePrevNotification"
                     object:nil];
 
 }

--- a/SquirrelApplicationDelegate.m
+++ b/SquirrelApplicationDelegate.m
@@ -1,5 +1,4 @@
 #import "SquirrelApplicationDelegate.h"
-#include <Foundation/Foundation.h>
 
 #import <rime_api.h>
 #import "SquirrelConfig.h"
@@ -21,12 +20,6 @@ static NSString *const kRimeWikiURL = @"https://github.com/rime/home/wiki";
 {
   NSLog(@"Sync user data");
   rime_get_api()->sync_user_data();
-}
-
--(void)userChange:(NSDictionary *)args
-{
-  NSLog(@"Sync user data");
-  [_panel changeToAscii:args];
 }
 
 -(IBAction)configure:(id)sender
@@ -221,15 +214,14 @@ void notification_handler(void* context_object, RimeSessionId session_id,
   [self syncUserData:nil];
 }
 
--(void)rimeNeedsChange:(NSNotification *)aNotification
+-(void)rimeChangeToAsciiMode:(NSNotification *)aNotification
 {
-  NSLog(@"Sync rime on demand.");
-  [self userChange:aNotification.userInfo];
+  [_panel changeToAscii];
 }
 
--(void)rimeNeedsPrev:(NSNotification *)aNotification
+-(void)rimeChangeToAsciiModePrev:(NSNotification *)aNotification
 {
-   [_panel changeToPrev];
+   [_panel changeToAsciiPrev];
 }
 
 -(NSApplicationTerminateReply)applicationShouldTerminate:(NSApplication *)sender
@@ -261,12 +253,12 @@ void notification_handler(void* context_object, RimeSessionId session_id,
                       name:@"SquirrelSyncNotification"
                     object:nil];
   [notifCenter addObserver:self
-                  selector:@selector(rimeNeedsChange:)
-                      name:@"SquirrelChangeNotification"
+                  selector:@selector(rimeChangeToAsciiMode:)
+                      name:@"SquirrelChangeToAsciiModeNotification"
                     object:nil];
   [notifCenter addObserver:self
-                  selector:@selector(rimeNeedsPrev:)
-                      name:@"SquirrelChangePrevNotification"
+                  selector:@selector(rimeChangeToAsciiModePrev:)
+                      name:@"SquirrelChangeToAsciiModePrevNotification"
                     object:nil];
 
 }

--- a/SquirrelInputController.h
+++ b/SquirrelInputController.h
@@ -4,4 +4,7 @@
 @interface SquirrelInputController : IMKInputController
 - (BOOL)selectCandidate:(NSInteger)index;
 - (BOOL)pageUp:(BOOL)up;
+-(void)changeToAscii:(NSDictionary *)args;
+-(void)changeToPrev;
+
 @end

--- a/SquirrelInputController.h
+++ b/SquirrelInputController.h
@@ -4,7 +4,7 @@
 @interface SquirrelInputController : IMKInputController
 - (BOOL)selectCandidate:(NSInteger)index;
 - (BOOL)pageUp:(BOOL)up;
--(void)changeToAscii:(NSDictionary *)args;
--(void)changeToPrev;
+-(void)changeToAscii;
+-(void)changeToAsciiPrev;
 
 @end

--- a/SquirrelInputController.m
+++ b/SquirrelInputController.m
@@ -166,12 +166,12 @@ const int N_KEY_ROLL_OVER = 50;
 
   return handled;
 }
--(void)changeToAscii:(NSDictionary *)args {
+-(void)changeToAscii {
     _prev =  [NSNumber numberWithBool:rime_get_api()->get_option(_session, "ascii_mode")];
     rime_get_api()->set_option(_session, "ascii_mode", True);
 }
 
--(void)changeToPrev {
+-(void)changeToAsciiPrev {
     if (_prev) {
         rime_get_api()->set_option(_session, "ascii_mode", [_prev boolValue]);
         _prev = nil;

--- a/SquirrelInputController.m
+++ b/SquirrelInputController.m
@@ -1,5 +1,4 @@
 #import "SquirrelInputController.h"
-#include <Foundation/Foundation.h>
 
 #import "SquirrelApplicationDelegate.h"
 #import "SquirrelConfig.h"

--- a/SquirrelInputController.m
+++ b/SquirrelInputController.m
@@ -1,4 +1,5 @@
 #import "SquirrelInputController.h"
+#include <Foundation/Foundation.h>
 
 #import "SquirrelApplicationDelegate.h"
 #import "SquirrelConfig.h"
@@ -36,6 +37,7 @@ const int N_KEY_ROLL_OVER = 50;
   NSTimer *_chordTimer;
   NSTimeInterval _chordDuration;
   NSString *_currentApp;
+  NSNumber *_prev;
 }
 
 /*!
@@ -163,6 +165,17 @@ const int N_KEY_ROLL_OVER = 50;
   _lastEventType = event.type;
 
   return handled;
+}
+-(void)changeToAscii:(NSDictionary *)args {
+    _prev =  [NSNumber numberWithBool:rime_get_api()->get_option(_session, "ascii_mode")];
+    rime_get_api()->set_option(_session, "ascii_mode", True);
+}
+
+-(void)changeToPrev {
+    if (_prev) {
+        rime_get_api()->set_option(_session, "ascii_mode", [_prev boolValue]);
+        _prev = nil;
+    }
 }
 
 -(BOOL)processKey:(int)rime_keycode modifiers:(int)rime_modifiers

--- a/SquirrelPanel.h
+++ b/SquirrelPanel.h
@@ -1,5 +1,4 @@
 #import <Cocoa/Cocoa.h>
-#include <Foundation/Foundation.h>
 #import "SquirrelInputController.h"
 
 @class SquirrelConfig;

--- a/SquirrelPanel.h
+++ b/SquirrelPanel.h
@@ -36,7 +36,7 @@
 -(void)loadConfig:(SquirrelConfig*)config
       forDarkMode:(BOOL)isDark;
 
--(void)changeToAscii:(NSDictionary *)args;
--(void)changeToPrev;
+-(void)changeToAscii;
+-(void)changeToAsciiPrev;
 
 @end

--- a/SquirrelPanel.h
+++ b/SquirrelPanel.h
@@ -1,4 +1,5 @@
 #import <Cocoa/Cocoa.h>
+#include <Foundation/Foundation.h>
 #import "SquirrelInputController.h"
 
 @class SquirrelConfig;
@@ -34,5 +35,8 @@
 
 -(void)loadConfig:(SquirrelConfig*)config
       forDarkMode:(BOOL)isDark;
+
+-(void)changeToAscii:(NSDictionary *)args;
+-(void)changeToPrev;
 
 @end

--- a/SquirrelPanel.m
+++ b/SquirrelPanel.m
@@ -1030,12 +1030,12 @@ NSAttributedString *insert(NSString *separator, NSAttributedString *betweenText)
   }
   return self;
 }
--(void)changeToAscii:(NSDictionary *)args {
-    [self.inputController changeToAscii:args];
+-(void)changeToAscii {
+    [self.inputController changeToAscii];
 }
 
--(void)changeToPrev {
-    [self.inputController changeToPrev];
+-(void)changeToAsciiPrev {
+    [self.inputController changeToAsciiPrev];
 }
 
 - (NSPoint)mousePosition {

--- a/SquirrelPanel.m
+++ b/SquirrelPanel.m
@@ -1030,6 +1030,13 @@ NSAttributedString *insert(NSString *separator, NSAttributedString *betweenText)
   }
   return self;
 }
+-(void)changeToAscii:(NSDictionary *)args {
+    [self.inputController changeToAscii:args];
+}
+
+-(void)changeToPrev {
+    [self.inputController changeToPrev];
+}
 
 - (NSPoint)mousePosition {
   NSPoint point = NSEvent.mouseLocation;

--- a/main.m
+++ b/main.m
@@ -62,17 +62,16 @@ int main(int argc, char *argv[]) {
     return 0;
   }
 
-  if (argc > 2 && !strcmp("--ascii_mode", argv[1])) {
+  if (argc > 1 && !strcmp("--ascii_mode", argv[1])) {
     [[NSDistributedNotificationCenter defaultCenter]
-        postNotificationName:@"SquirrelChangeNotification"
-                      object: nil
-                    userInfo:@{@"ascii_mode" : [NSString stringWithFormat:@"%s", argv[2]]}];
+        postNotificationName:@"SquirrelChangeToAsciiModeNotification"
+                      object: nil];
     return 0;
   }
 
   if (argc > 1 && !strcmp("--ascii_mode_prev", argv[1])) {
     [[NSDistributedNotificationCenter defaultCenter]
-        postNotificationName:@"SquirrelChangePrevNotification"
+        postNotificationName:@"SquirrelChangeToAsciiModePrevNotification"
                       object: nil];
     return 0;
   }

--- a/main.m
+++ b/main.m
@@ -1,5 +1,6 @@
 
 #import "SquirrelApplicationDelegate.h"
+#include <Foundation/Foundation.h>
 #import <Cocoa/Cocoa.h>
 #import <InputMethodKit/InputMethodKit.h>
 #import <rime_api.h>
@@ -61,6 +62,22 @@ int main(int argc, char *argv[]) {
     return 0;
   }
 
+  if (argc > 2 && !strcmp("--ascii_mode", argv[1])) {
+    [[NSDistributedNotificationCenter defaultCenter]
+        postNotificationName:@"SquirrelChangeNotification"
+                      object: nil
+                    userInfo:@{@"ascii_mode" : [NSString stringWithFormat:@"%s", argv[2]]}];
+    return 0;
+  }
+
+  if (argc > 1 && !strcmp("--ascii_mode_prev", argv[1])) {
+    [[NSDistributedNotificationCenter defaultCenter]
+        postNotificationName:@"SquirrelChangePrevNotification"
+                      object: nil];
+    return 0;
+  }
+
+
   @autoreleasepool {
     // find the bundle identifier and then initialize the input method server
     NSBundle *main = [NSBundle mainBundle];
@@ -70,7 +87,9 @@ int main(int argc, char *argv[]) {
 
     // load the bundle explicitly because in this case the input method is a
     // background only application
-    [main loadNibNamed:@"MainMenu" owner:[NSApplication sharedApplication] topLevelObjects:NULL];
+    [main loadNibNamed:@"MainMenu"
+                  owner:[NSApplication sharedApplication]
+        topLevelObjects:NULL];
 
     // opencc will be configured with relative dictionary paths
     [[NSFileManager defaultManager]
@@ -78,11 +97,9 @@ int main(int argc, char *argv[]) {
 
     if (NSApp.squirrelAppDelegate.problematicLaunchDetected) {
       NSLog(@"Problematic launch detected!");
-      NSArray *args = @[
-        @"Problematic launch detected! \
+      NSArray *args = @[ @"Problematic launch detected! \
                        Squirrel may be suffering a crash due to imporper configuration. \
-                       Revert previous modifications to see if the problem recurs."
-      ];
+                       Revert previous modifications to see if the problem recurs." ];
       [NSTask launchedTaskWithLaunchPath:@"/usr/bin/say" arguments:args];
     } else {
       [NSApp.squirrelAppDelegate setupRime];
@@ -93,6 +110,7 @@ int main(int argc, char *argv[]) {
 
     // finally run everything
     [[NSApplication sharedApplication] run];
+
 
     NSLog(@"Squirrel is quitting...");
     rime_get_api()->finalize();

--- a/main.m
+++ b/main.m
@@ -1,6 +1,5 @@
 
 #import "SquirrelApplicationDelegate.h"
-#include <Foundation/Foundation.h>
 #import <Cocoa/Cocoa.h>
 #import <InputMethodKit/InputMethodKit.h>
 #import <rime_api.h>
@@ -109,7 +108,6 @@ int main(int argc, char *argv[]) {
 
     // finally run everything
     [[NSApplication sharedApplication] run];
-
 
     NSLog(@"Squirrel is quitting...");
     rime_get_api()->finalize();


### PR DESCRIPTION
`/Library/Input\ Methods/Squirrel.app/Contents/MacOS/Squirrel --ascii_mode` 切换到 ascii 模式
`/Library/Input\ Methods/Squirrel.app/Contents/MacOS/Squirrel --ascii_mode_prev` 切换到之前的模式

通过这个 feature 可以做到在 neovim 中更精确的控制输入法模式
