### PR TITLE
Upgrade GitHub action to v4

### DIFF
--- a/.github/workflows/commit-ci.yml
+++ b/.github/workflows/commit-ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout last commit
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
 
@@ -20,7 +20,7 @@ jobs:
         run: ./action-build.sh package
 
       - name: Upload Squirrel artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Squirrel-${{ env.git_ref_name }}.zip
           path: package/*.pkg

--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout last commit
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
 
@@ -17,7 +17,7 @@ jobs:
         run: ./action-build.sh package
 
       - name: Upload Squirrel artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Squirrel-${{ env.git_ref_name }}.zip
           path: package/*.pkg

--- a/.github/workflows/release-ci.yml
+++ b/.github/workflows/release-ci.yml
@@ -10,7 +10,7 @@ jobs:
       SQUIRREL_BUNDLED_RECIPES: 'lotem/rime-octagram-data lotem/rime-octagram-data@hant'
     steps:
       - name: Checkout last commit
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true


### PR DESCRIPTION
Upgrade Github action to v4

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/upload-artifact@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

