### PR TITLE
chore: use macos 14 runner with M1

### DIFF
--- a/.github/workflows/commit-ci.yml
+++ b/.github/workflows/commit-ci.yml
@@ -5,7 +5,7 @@ on:
       - '*'
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-14
     steps:
       - name: Checkout last commit
         uses: actions/checkout@v3

--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -2,7 +2,7 @@ name: pull request ci
 on: [pull_request]
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-14
     steps:
       - name: Checkout last commit
         uses: actions/checkout@v3

--- a/.github/workflows/release-ci.yml
+++ b/.github/workflows/release-ci.yml
@@ -5,7 +5,7 @@ on:
       - '*'
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-14
     env:
       SQUIRREL_BUNDLED_RECIPES: 'lotem/rime-octagram-data lotem/rime-octagram-data@hant'
     steps:


### PR DESCRIPTION
Use macos14 runner with M1 to speed up the CI, decrease from 3m 7s to about 1m 28s.
 
https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/

