### PR TITLE
chore: upgrade to librime 1.11.0

### DIFF
--- a/action-install.sh
+++ b/action-install.sh
@@ -2,13 +2,13 @@
 
 set -e
 
-rime_version=1.8.5
-rime_git_hash=08dd95f
+rime_version=1.11.0
+rime_git_hash=76a0a16
 
-rime_archive="rime-${rime_git_hash}-macOS.tar.bz2"
+rime_archive="rime-${rime_git_hash}-macOS-universal.tar.bz2"
 rime_download_url="https://github.com/rime/librime/releases/download/${rime_version}/${rime_archive}"
 
-rime_deps_archive="rime-deps-${rime_git_hash}-macOS.tar.bz2"
+rime_deps_archive="rime-deps-${rime_git_hash}-macOS-universal.tar.bz2"
 rime_deps_download_url="https://github.com/rime/librime/releases/download/${rime_version}/${rime_deps_archive}"
 
 mkdir -p download && (


### PR DESCRIPTION
Previously, `action-install.sh` was not updated accordingly, and the build artifact is completely unusable.