### PR TITLE
ci: disable nightly build in forked repos

### DIFF
--- a/.github/workflows/release-ci.yml
+++ b/.github/workflows/release-ci.yml
@@ -47,7 +47,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create nightly release
-        if: github.ref == 'refs/heads/master'
+        if: ${{ github.repository == 'rime/squirrel' && github.ref == 'refs/heads/master' }}
         uses: 'marvinpinto/action-automatic-releases@latest'
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
https://github.com/rime/librime/pull/846

The forked repos nightly build will waste a myriad of CPU resources.
