### PR TITLE
Remove clang format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,2 +1,0 @@
-BasedOnStyle: Chromium
-SortIncludes: false

--- a/.github/workflows/commit-ci.yml
+++ b/.github/workflows/commit-ci.yml
@@ -12,12 +12,6 @@ jobs:
         with:
           submodules: true
 
-      - name: Install clang-format
-        run: brew install clang-format
-
-      - name: Lint
-        run: make clang-format-lint
-
       - name: Configure build environment
         run: |
           echo git_ref_name="$(git describe --always)" >> $GITHUB_ENV

--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -9,12 +9,6 @@ jobs:
         with:
           submodules: true
 
-      - name: Install clang-format
-        run: brew install clang-format
-
-      - name: Lint
-        run: make clang-format-lint
-
       - name: Configure build environment
         run: |
           echo git_ref_name="$(git describe --always)" >> $GITHUB_ENV

--- a/.github/workflows/release-ci.yml
+++ b/.github/workflows/release-ci.yml
@@ -19,12 +19,6 @@ jobs:
           fetch-depth: 0
           submodules: true
 
-      - name: Install clang-format
-        run: brew install clang-format
-
-      - name: Lint
-        run: make clang-format-lint
-
       - name: Build Squirrel
         run: ./action-build.sh archive
 

--- a/Makefile
+++ b/Makefile
@@ -84,12 +84,6 @@ copy-opencc-data:
 
 deps: librime data
 
-clang-format-lint:
-	find . -name '*.m' -o -name '*.h' -maxdepth 1 | xargs clang-format -Werror --dry-run || { echo Please lint your code by '"'"make clang-format-apply"'"'.; false; }
-
-clang-format-apply:
-	find . -name '*.m' -o -name '*.h' -maxdepth 1 | xargs clang-format --verbose -i
-
 ifdef ARCHS
 BUILD_SETTINGS += ARCHS="$(ARCHS)"
 BUILD_SETTINGS += ONLY_ACTIVE_ARCH=NO


### PR DESCRIPTION
Remove clang format due to we had been migrated to Swift.

- **ci: delete clang format lint step**
- **build: remove clang format target**
- **chore: remove clang format config**

