### PR TITLE
Add report_bundleid to allow App Bundle ID to be accessible from librime

### DIFF
--- a/sources/SquirrelInputController.swift
+++ b/sources/SquirrelInputController.swift
@@ -353,6 +353,11 @@ private extension SquirrelInputController {
         rimeAPI.set_option(session, key, value)
       }
     }
+    if let reportBundleID = NSApp.squirrelAppDelegate.config?.getBool("unsafe/report_bundleid"), reportBundleID {
+      currentApp.withCString { name in
+        rimeAPI.set_property(session, "client_app", name)
+      }
+    }
   }
 
   func destroySession() {


### PR DESCRIPTION
Weasel reports current App name by setting "client_app" in librime property.

This can be potentially useful for Lua based app specific functions. But needs to be explicitly enabled by user in `squirrel.custom.yaml` like:

```yaml
# squirrel.custom.yaml
patch:
  unsafe/report_bundleid: true
```

Without specifically setting this option to true, bundle id will not be reported to librime (default)