### PR TITLE
fix(SquirrelInputController): boundary check to prevent crash

### DIFF
--- a/sources/SquirrelInputController.swift
+++ b/sources/SquirrelInputController.swift
@@ -468,7 +468,7 @@ private extension SquirrelInputController {
           if end < caretPos && start < caretPos {
             candidatePreview = String(candidatePreview[..<candidatePreview.index(candidatePreview.endIndex, offsetBy: -max(0, preedit.distance(from: end, to: caretPos)))])
           } else if end < preedit.endIndex && caretPos <= start {
-            candidatePreview = String(candidatePreview[..<candidatePreview.index(candidatePreview.endIndex, offsetBy: -max(0, preedit.distance(from: end, to: preedit.endIndex)))])
+            candidatePreview = String(candidatePreview[..<candidatePreview.index(candidatePreview.endIndex, offsetBy: -min(candidatePreview.count, max(0, preedit.distance(from: end, to: preedit.endIndex))))])
           }
           show(preedit: candidatePreview,
                selRange: NSRange(location: start.utf16Offset(in: candidatePreview), length: candidatePreview.utf16.distance(from: start, to: candidatePreview.endIndex)),

--- a/sources/SquirrelInputController.swift
+++ b/sources/SquirrelInputController.swift
@@ -466,18 +466,12 @@ private extension SquirrelInputController {
                caretPos: candidatePreview.utf16.count - max(0, preedit.utf16.distance(from: caretPos, to: preedit.endIndex)))
         } else {
           if end < caretPos && start < caretPos {
-            let trimCount = preedit.distance(from: end, to: caretPos).clamped(to: 0..<candidatePreview.count)
-            candidatePreview = String(candidatePreview[..<candidatePreview.index(candidatePreview.endIndex, offsetBy: -trimCount)])
+            candidatePreview = String(candidatePreview[..<candidatePreview.index(candidatePreview.endIndex, offsetBy: -max(0, preedit.distance(from: end, to: caretPos)))])
           } else if end < preedit.endIndex && caretPos <= start {
-            let trimCount = preedit.distance(from: end, to: preedit.endIndex).clamped(to: 0..<candidatePreview.count)
-            candidatePreview = String(candidatePreview[..<candidatePreview.index(candidatePreview.endIndex, offsetBy: -trimCount)])
+            candidatePreview = String(candidatePreview[..<candidatePreview.index(candidatePreview.endIndex, offsetBy: -max(0, preedit.distance(from: end, to: preedit.endIndex)))])
           }
-          
-          let selStart = candidatePreview.isEmpty ? 0 : start.utf16Offset(in: candidatePreview)
-          let selLength = candidatePreview.utf16.count - selStart
-          
           show(preedit: candidatePreview,
-               selRange: NSRange(location: selStart, length: selLength),
+               selRange: NSRange(location: start.utf16Offset(in: candidatePreview), length: candidatePreview.utf16.distance(from: start, to: candidatePreview.endIndex)),
                caretPos: candidatePreview.utf16.count)
         }
       } else {
@@ -570,12 +564,4 @@ private extension SquirrelInputController {
                    highlighted: highlighted, page: page, lastPage: lastPage, update: true)
     }
   }
-}
-
-// clamp value into half open interval
-extension BinaryInteger {
-    func clamped(to limits: Range<Self>) -> Self {
-      guard !limits.isEmpty else { return limits.lowerBound }
-        return min(max(self, limits.lowerBound), limits.upperBound - 1)
-    }
 }


### PR DESCRIPTION
Make sure candidatePreview is trimmed only when it is legal
Fallback to empty string  when pulling out the switcher with caption as preedit text

This seems to solve the problem mentioned in #1041