### PR TITLE
feat: allow global ascii_mode to be enabled via the `global_ascii` configuration item

### DIFF
--- a/data/squirrel.yaml
+++ b/data/squirrel.yaml
@@ -15,6 +15,9 @@ chord_duration: 0.1  # seconds
 # options: always | never | appropriate
 show_notifications_when: appropriate
 
+# whether to enable global sharing the same `ascii_mode`, default to false
+global_ascii: false
+
 style:
   color_scheme: native
   # Optional: define both light and dark color schemes to match system appearance

--- a/sources/SquirrelInputController.swift
+++ b/sources/SquirrelInputController.swift
@@ -10,6 +10,7 @@ import InputMethodKit
 final class SquirrelInputController: IMKInputController {
   private static let keyRollOver = 50
   private static var unknownAppCnt: UInt = 0
+  // swiftlint:disable:next identifier_name
   private static let USER_ASCII_MODE_KEY = "_user_global_ascii_mode"
 
   private weak var client: IMKTextInput?
@@ -371,13 +372,19 @@ private extension SquirrelInputController {
   }
 
   func updateAsciiMode(_ handled: Bool) {
+    // swiftlint:disable:next identifier_name
+    let _shared_ascii_mode = NSApp.squirrelAppDelegate.config?.getBool("global_ascii") ?? false
+    if !_shared_ascii_mode {
+      return
+    }
+
     let userAsciiMode = UserDefaults.standard.bool(forKey: SquirrelInputController.USER_ASCII_MODE_KEY)
     let asciiMode = rimeAPI.get_option(session, "ascii_mode")
-    if(asciiMode == userAsciiMode) {
+    if asciiMode == userAsciiMode {
       // ascii 模式状态一致的情况下不需要同步状态
       return
     }
-    if(handled) {
+    if handled {
       // 处理之后，以 rime 状态为主，更新用户配置
       UserDefaults.standard.set(asciiMode, forKey: SquirrelInputController.USER_ASCII_MODE_KEY)
     } else {

--- a/sources/SquirrelInputController.swift
+++ b/sources/SquirrelInputController.swift
@@ -371,7 +371,7 @@ private extension SquirrelInputController {
     clearChord()
   }
 
-  func updateAsciiMode(_ handled: Bool) {
+  func updateAsciiMode(_ record: Bool) {
     // swiftlint:disable:next identifier_name
     let _shared_ascii_mode = NSApp.squirrelAppDelegate.config?.getBool("global_ascii") ?? false
     if !_shared_ascii_mode {
@@ -384,7 +384,7 @@ private extension SquirrelInputController {
       // ascii 模式状态一致的情况下不需要同步状态
       return
     }
-    if handled {
+    if record {
       // 处理之后，以 rime 状态为主，更新用户配置
       UserDefaults.standard.set(asciiMode, forKey: SquirrelInputController.USER_ASCII_MODE_KEY)
     } else {
@@ -408,9 +408,10 @@ private extension SquirrelInputController {
     }
 
     updateAsciiMode(false) // 按键事件处理前的 ascii 模式状态同步
+    defer { updateAsciiMode(true) } // 按键事件处理后的 ascii 模式状态同步
+
     let handled = rimeAPI.process_key(session, Int32(rimeKeycode), Int32(rimeModifiers))
     // print("[DEBUG] rime_keycode: \(rimeKeycode), rime_modifiers: \(rimeModifiers), handled = \(handled)")
-    updateAsciiMode(true) // 按键事件处理后的 ascii 模式状态同步
 
     // TODO add special key event postprocessing here
 


### PR DESCRIPTION
问题：
在最新的 macOS 系统设置已不支持配置全局使用同一个 InputConnection（[~~"Use one input source in all documents" Deprecated~~](https://github.com/rime/librime/issues/294#issuecomment-2764993407)），故部分用户需要 squirrel 实现前端记录全局的 ascii_mode 以实现在任意应用任意输入框中有可预期的 ascii 模式输入体验。

相关问题：
https://github.com/rime/squirrel/issues/145
https://github.com/rime/squirrel/issues/999
https://github.com/rime/squirrel/pull/201
https://github.com/rime/librime/issues/294

解决方案：
在了解整体问题上下文后，决定通过以下方式实现
- 在 squirrel.yaml 配置文件中增加 `global_ascii: bool` 字段用于控制是否全局记录 ascii_mode，其默认值为 false
- 当 global_ascii 为 true 时 squirrel 会使用 UserDefaults.standard 记录以 `_user_global_ascii_mode` 为 key 记录 ascii_mode 并在每次创建新的（或重新激活旧的）InputConnection 时读取并以此设置的值为 ascii_mode 最高优先级

可遇见的问题：
使用该功能后可能会导致忽略用户配置的 app_options.ascii_mode 字段失效（编者是能接受在明确启用全局 ascii_mode 模式后应该以全局配置项为准的配置优先级的，如果有更好的实现方式或想法欢迎留言一起讨论实现，我愿意为推进此功能持续工作）

TBR; @lotem @LEOYoon-Tsaw 

最后感谢 lotem 和 rime 贡献者们以及社区伟大的工作
