### PR TITLE
fix: light mode to dark mode switch not working in native theme (rime#1058)

### DIFF
--- a/sources/SquirrelPanel.swift
+++ b/sources/SquirrelPanel.swift
@@ -354,6 +354,8 @@ private extension SquirrelPanel {
     let theme = view.currentTheme
     if !view.darkTheme.available {
       self.appearance = NSAppearance(named: .aqua)
+    } else if theme.native {
+      self.appearance = NSAppearance(named: .darkAqua)
     }
 
     // Break line if the text is too long, based on screen size.


### PR DESCRIPTION
closes https://github.com/rime/squirrel/issues/1058