### PR TITLE
Add support for hiding candidate list via Rime option _hide_candidate

### DIFF
--- a/sources/SquirrelInputController.swift
+++ b/sources/SquirrelInputController.swift
@@ -515,24 +515,24 @@ private extension SquirrelInputController {
       let numCandidates = Int(ctx.menu.num_candidates)
       var candidates = [String]()
       var comments = [String]()
+      var labels = [String]()
       if !rimeAPI.get_option(session, "_hide_candidate") {
         for i in 0..<numCandidates {
           let candidate = ctx.menu.candidates[i]
           candidates.append(candidate.text.map { String(cString: $0) } ?? "")
           comments.append(candidate.comment.map { String(cString: $0) } ?? "")
         }
-      }
-      var labels = [String]()
-      // swiftlint:disable identifier_name
-      if let select_keys = ctx.menu.select_keys {
-        labels = String(cString: select_keys).map { String($0) }
-      } else if let select_labels = ctx.select_labels {
-        let pageSize = Int(ctx.menu.page_size)
-        for i in 0..<pageSize {
-          labels.append(select_labels[i].map { String(cString: $0) } ?? "")
+        // swiftlint:disable identifier_name
+        if let select_keys = ctx.menu.select_keys {
+          labels = String(cString: select_keys).map { String($0) }
+        } else if let select_labels = ctx.select_labels {
+          let pageSize = Int(ctx.menu.page_size)
+          for i in 0..<pageSize {
+            labels.append(select_labels[i].map { String(cString: $0) } ?? "")
+          }
         }
+        // swiftlint:enable identifier_name
       }
-      // swiftlint:enable identifier_name
       let page = Int(ctx.menu.page_no)
       let lastPage = ctx.menu.is_last_page
 


### PR DESCRIPTION
This pull request introduces the ability to control whether the candidate list is displayed through a Rime option (_hide_candidate). This feature was originally implemented in [Trime](https://github.com/osfans/trime).

When the option is enabled, Squirrel will skip populating and showing the candidate list, allowing users or schemas to dynamically hide candidates without relying on theme configuration.

Usage Example
```yaml
#in xxx.schema.yaml or xxx.custom.yaml
switches:
  - name: _hide_candidate
    reset: 1
```

1. When _hide_candidate is 1, the candidate list remains empty and the candidate window stays hidden.
2. Default behavior remains unchanged (candidates are shown unless explicitly hidden).
3. No impact on existing configurations.
4. The _hide_candidate option is optional and off by default.
5. Fully compatible with existing themes and styles.

**If the name _hide_candidate is not suitable, feel free to rename it to a more appropriate one.**
