### PR TITLE
Upgrade action and image runner

### DIFF
--- a/.github/workflows/commit-ci.yml
+++ b/.github/workflows/commit-ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout last commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: true
 
@@ -32,7 +32,7 @@ jobs:
         run: periphery scan --relative-results --skip-build --index-store-path build/Index.noindex/DataStore
 
       - name: Upload Squirrel artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: Squirrel-${{ env.git_ref_name }}.zip
           path: package/*.pkg

--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout last commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: true
 
@@ -29,7 +29,7 @@ jobs:
         run: periphery scan --relative-results --skip-build --index-store-path build/Index.noindex/DataStore
 
       - name: Upload Squirrel artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: Squirrel-${{ env.git_ref_name }}.zip
           path: package/*.pkg

--- a/.github/workflows/release-ci.yml
+++ b/.github/workflows/release-ci.yml
@@ -14,7 +14,7 @@ jobs:
       SQUIRREL_BUNDLED_RECIPES: 'lotem/rime-octagram-data lotem/rime-octagram-data@hant'
     steps:
       - name: Checkout last commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           submodules: true


### PR DESCRIPTION
Upgrade action with node 24 and image runner to macos-latest.

macos-14 will be deprecated from July 6th.

http://github.com/actions/runner-images/issues/13518
