### PR TITLE
修复远程桌面软件按 modifier key 时产生幽灵 'a' 按键的问题

### DIFF
--- a/sources/MacOSKeyCodes.swift
+++ b/sources/MacOSKeyCodes.swift
@@ -65,6 +65,30 @@ struct SquirrelKeycode {
     return UInt32(XK_VoidSymbol)
   }
 
+  static let modifierKeycodes: Set<UInt16> = [
+    UInt16(kVK_Shift), UInt16(kVK_RightShift),
+    UInt16(kVK_CapsLock),
+    UInt16(kVK_Control), UInt16(kVK_RightControl),
+    UInt16(kVK_Option), UInt16(kVK_RightOption),
+    UInt16(kVK_Command), UInt16(kVK_RightCommand),
+    UInt16(kVK_Function)
+  ]
+
+  static func inferModifierKeycode(from changes: NSEvent.ModifierFlags) -> UInt16? {
+    if changes.contains(.capsLock) {
+      return UInt16(kVK_CapsLock)
+    } else if changes.contains(.shift) {
+      return UInt16(kVK_Shift)
+    } else if changes.contains(.control) {
+      return UInt16(kVK_Control)
+    } else if changes.contains(.option) {
+      return UInt16(kVK_Option)
+    } else if changes.contains(.command) {
+      return UInt16(kVK_Command)
+    }
+    return nil
+  }
+
   private static let keycodeMappings: [Int: Int32] = [
     // modifiers
     kVK_CapsLock: XK_Caps_Lock,

--- a/sources/SquirrelInputController.swift
+++ b/sources/SquirrelInputController.swift
@@ -62,9 +62,37 @@ final class SquirrelInputController: IMKInputController {
       }
       // print("[DEBUG] FLAGSCHANGED client: \(sender ?? "nil"), modifiers: \(modifiers)")
       var rimeModifiers: UInt32 = SquirrelKeycode.osxModifiersToRime(modifiers: modifiers)
-      // For flags-changed event, keyCode is available since macOS 10.15
-      // (#715)
-      let rimeKeycode: UInt32 = SquirrelKeycode.osxKeycodeToRime(keycode: event.keyCode, keychar: nil, shift: false, caps: false)
+      // For flags-changed event, keyCode is available since macOS 10.15 (#715)
+      // Some remote desktop software (e.g. Parsec) sends flagsChanged events with
+      // keyCode defaulting to 0 (kVK_ANSI_A) instead of the actual modifier keycode,
+      // causing a ghost 'a' keypress. Validate and infer the correct keycode from
+      // the changed modifier flags when necessary. (#825)
+      let modifierKeycodes: Set<UInt16> = [
+        UInt16(kVK_Shift), UInt16(kVK_RightShift),
+        UInt16(kVK_CapsLock),
+        UInt16(kVK_Control), UInt16(kVK_RightControl),
+        UInt16(kVK_Option), UInt16(kVK_RightOption),
+        UInt16(kVK_Command), UInt16(kVK_RightCommand),
+        UInt16(kVK_Function)
+      ]
+      var keyCode = event.keyCode
+      if !modifierKeycodes.contains(keyCode) {
+        if changes.contains(.capsLock) {
+          keyCode = UInt16(kVK_CapsLock)
+        } else if changes.contains(.shift) {
+          keyCode = UInt16(kVK_Shift)
+        } else if changes.contains(.control) {
+          keyCode = UInt16(kVK_Control)
+        } else if changes.contains(.option) {
+          keyCode = UInt16(kVK_Option)
+        } else if changes.contains(.command) {
+          keyCode = UInt16(kVK_Command)
+        } else {
+          handled = true
+          break
+        }
+      }
+      let rimeKeycode: UInt32 = SquirrelKeycode.osxKeycodeToRime(keycode: keyCode, keychar: nil, shift: false, caps: false)
 
       if changes.contains(.capsLock) {
         // NOTE: rime assumes XK_Caps_Lock to be sent before modifier changes,

--- a/sources/SquirrelInputController.swift
+++ b/sources/SquirrelInputController.swift
@@ -67,30 +67,15 @@ final class SquirrelInputController: IMKInputController {
       // keyCode defaulting to 0 (kVK_ANSI_A) instead of the actual modifier keycode,
       // causing a ghost 'a' keypress. Validate and infer the correct keycode from
       // the changed modifier flags when necessary. (#825)
-      let modifierKeycodes: Set<UInt16> = [
-        UInt16(kVK_Shift), UInt16(kVK_RightShift),
-        UInt16(kVK_CapsLock),
-        UInt16(kVK_Control), UInt16(kVK_RightControl),
-        UInt16(kVK_Option), UInt16(kVK_RightOption),
-        UInt16(kVK_Command), UInt16(kVK_RightCommand),
-        UInt16(kVK_Function)
-      ]
       var keyCode = event.keyCode
-      if !modifierKeycodes.contains(keyCode) {
-        if changes.contains(.capsLock) {
-          keyCode = UInt16(kVK_CapsLock)
-        } else if changes.contains(.shift) {
-          keyCode = UInt16(kVK_Shift)
-        } else if changes.contains(.control) {
-          keyCode = UInt16(kVK_Control)
-        } else if changes.contains(.option) {
-          keyCode = UInt16(kVK_Option)
-        } else if changes.contains(.command) {
-          keyCode = UInt16(kVK_Command)
-        } else {
+      if !SquirrelKeycode.modifierKeycodes.contains(keyCode) {
+        guard let inferred = SquirrelKeycode.inferModifierKeycode(from: changes) else {
+          lastModifiers = modifiers
+          rimeUpdate()
           handled = true
           break
         }
+        keyCode = inferred
       }
       let rimeKeycode: UInt32 = SquirrelKeycode.osxKeycodeToRime(keycode: keyCode, keychar: nil, shift: false, caps: false)
 


### PR DESCRIPTION
## 概述

修复 #825

部分远程桌面软件（如 **Parsec**、旧版 **Deskflow**）通过 `IOHIDPostEvent` 发送 `flagsChanged` 事件时，未正确设置 `event.key.keyCode`，导致其默认为 `0`（即 macOS 上的 `kVK_ANSI_A`）。自 PR #936 新增 `additionalCodeMappings` 后，`osxKeycodeToRime()` 会将 keycode 0 映射为 `XK_a`，导致通过远程桌面按下 Shift、CapsLock 等 modifier key 时产生**幽灵 'a' 按键**。

### 根因分析

1. 远程桌面软件发送 `NX_FLAGSCHANGED` 事件时 `keyCode = 0`（默认值），而非实际的 modifier key virtual keycode
2. `osxKeycodeToRime(keycode: 0, keychar: nil, ...)` → `keycodeMappings` 中无 0 的映射 → `keychar` 为 `nil` 跳过 ASCII 路径 → `additionalCodeMappings[0]` 返回 `XK_a`（因为 `kVK_ANSI_A == 0`）

### 修复方案

在 `.flagsChanged` 处理逻辑中，校验 `event.keyCode` 是否对应已知的 modifier key virtual keycode（`kVK_Shift`、`kVK_CapsLock` 等）。当检测到无效的 keycode（如 0）时，从变化的 modifier flags（`NSEvent.ModifierFlags`）推断正确的 modifier keycode。

这是 **Squirrel 侧的防御性修复**——虽然 bug 源自远程桌面软件未正确设置 keyCode（[Deskflow 已在 deskflow/deskflow#9435 修复](https://github.com/deskflow/deskflow/pull/9435)），但 Parsec 等闭源软件可能不会及时修复。让 Squirrel 对 `flagsChanged` 事件中的无效 keycode 具备容错能力是更合理的做法。

### 局限性

从 flags 推断 keycode 时，无法区分左右 modifier（如 `Shift_L` vs `Shift_R`），因此默认使用左侧。但这仅影响 `event.keyCode` 本身已经无效的情况。

## 测试计划

- [ ] 验证本地键盘的 Shift/CapsLock/Control/Option/Command 中英切换功能正常
- [ ] 验证通过 Parsec（或类似远程桌面）按 Shift/CapsLock 不再产生幽灵 'a' 按键
- [ ] 验证 modifier key 的释放事件处理正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>