### PR TITLE
Fix: 候选词面板首次聚焦时漂移到屏幕左上角

### DIFF
--- a/sources/SquirrelInputController.swift
+++ b/sources/SquirrelInputController.swift
@@ -548,9 +548,19 @@ private extension SquirrelInputController {
       let lastPage = ctx.menu.is_last_page
 
       let selRange = NSRange(location: start.utf16Offset(in: preedit), length: preedit.utf16.distance(from: start, to: end))
-      showPanel(preedit: inlinePreedit ? "" : preedit, selRange: selRange, caretPos: caretPos.utf16Offset(in: preedit),
-                candidates: candidates, comments: comments, labels: labels, highlighted: Int(ctx.menu.highlighted_candidate_index),
-                page: page, lastPage: lastPage)
+      // Defer showPanel to the next run loop iteration so the client has
+      // time to process the setMarkedText call from show(). Without this,
+      // attributes(forCharacterIndex:lineHeightRectangle:) may return an
+      // invalid position when the text view hasn't laid out yet (e.g. first
+      // focus in Chrome).
+      let panelPreedit = inlinePreedit ? "" : preedit
+      let panelCaretPos = caretPos.utf16Offset(in: preedit)
+      let panelHighlighted = Int(ctx.menu.highlighted_candidate_index)
+      DispatchQueue.main.async { [weak self] in
+        self?.showPanel(preedit: panelPreedit, selRange: selRange, caretPos: panelCaretPos,
+                        candidates: candidates, comments: comments, labels: labels, highlighted: panelHighlighted,
+                        page: page, lastPage: lastPage)
+      }
       _ = rimeAPI.free_context(&ctx)
     } else {
       hidePalettes()
@@ -594,9 +604,22 @@ private extension SquirrelInputController {
     // print("[DEBUG] showPanelWithPreedit:...:")
     guard let client = client else { return }
     var inputPos = NSRect()
-    client.attributes(forCharacterIndex: 0, lineHeightRectangle: &inputPos)
+    _ = client.attributes(forCharacterIndex: 0, lineHeightRectangle: &inputPos)
+
     if let panel = NSApp.squirrelAppDelegate.panel {
-      panel.position = inputPos
+      // Validate the position: must have non-zero height and the origin must
+      // not be at the screen origin (0,0). A text cursor at the exact screen
+      // origin is virtually impossible — when the client hasn't finished
+      // layout (e.g. first focus in Chrome), it often returns a rect near
+      // (0,0) with a non-zero height.
+      if inputPos.height > 0 && (abs(inputPos.origin.x) > 1 || abs(inputPos.origin.y) > 1) {
+        panel.position = inputPos
+      } else if panel.position.height <= 0 {
+        // No valid previous position either — fall back to the mouse cursor
+        // location so the panel appears roughly where the user clicked.
+        let mouse = NSEvent.mouseLocation
+        panel.position = NSRect(x: mouse.x, y: mouse.y, width: 0, height: 20)
+      }
       panel.inputController = self
       panel.update(preedit: preedit, selRange: selRange, caretPos: caretPos, candidates: candidates, comments: comments, labels: labels,
                    highlighted: highlighted, page: page, lastPage: lastPage, update: true)


### PR DESCRIPTION
经常会遇到这个问题，有点难受，用 AI 处理了，效果不错 https://github.com/rime/squirrel/issues/870

问题描述
在中文输入模式下，首次聚焦某个可输入区域（如 Chrome 搜索框）时，候选词面板会漂移到屏幕左上角。第二次及之后输入则正常。

根因分析
rimeUpdate() 中 show() 调用 client.setMarkedText() 后，紧接着 showPanel() 调用 client.attributes(forCharacterIndex:lineHeightRectangle:) 查询光标位置。某些客户端（如 Chrome 多进程架构）在收到 setMarkedText 后尚未完成布局，此时 attributes 返回的 lineHeightRectangle 接近 (0,0)，导致候选框定位到屏幕左上角。

修复内容
延迟 showPanel 到下一个 run loop：给客户端一个 run loop 迭代的时间处理 setMarkedText 并完成布局，使 attributes 能返回正确的光标位置

增加位置有效性校验：即使延迟后仍可能拿到无效位置，增加 height > 0 且 origin 偏离屏幕原点 的双重校验；无效时保留前一次有效位置，若无前位置则用鼠标坐标兜底；使用 abs() 判断支持多显示器负坐标场景

影响范围
仅修改 [SquirrelInputController.swift] 不影响其他模块。