### PR TITLE
switch to non ascii mode on re-active

### DIFF
--- a/sources/SquirrelInputController.swift
+++ b/sources/SquirrelInputController.swift
@@ -194,6 +194,10 @@ final class SquirrelInputController: IMKInputController {
     if keyboardLayout != "" {
       client?.overrideKeyboard(withKeyboardNamed: keyboardLayout)
     }
+    if session != 0 {
+      rimeAPI.set_option(session, "ascii_mode", false)
+      updateAppOptions()
+    }
     preedit = ""
   }
 


### PR DESCRIPTION
When a user switches to another input method and then switches back, in practice, it almost always involves switching to an English input method and then back. In this situation, the user definitely wants to input Chinese. However, the input method might be recording ASCII mode, which doesn't match the user's expectation. This submission explicitly states that in this case, the user should switch back to Chinese mode.

当用户切换到别的输入法，再切换回来，在实际中，几乎一定是切到英文输入法，再切换回来。在这种情况下，用户肯定是希望输入中文的。但输入法可能记录了ascii mode，从而与用户预期不符。这个提交明确在此种情况下切换回中文模式