### PR TITLE
Adopts glass effect on macOS 26+

### DIFF
--- a/.github/workflows/commit-ci.yml
+++ b/.github/workflows/commit-ci.yml
@@ -7,6 +7,11 @@ jobs:
   build:
     runs-on: macos-latest
     steps:
+      - name: Set Xcode version
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
       - name: Checkout last commit
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/commit-ci.yml
+++ b/.github/workflows/commit-ci.yml
@@ -5,12 +5,12 @@ on:
       - '*'
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-26
     steps:
       - name: Set Xcode version
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: latest-stable
+          xcode-version: '26.5'
 
       - name: Checkout last commit
         uses: actions/checkout@v6

--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -2,12 +2,12 @@ name: pull request ci
 on: [pull_request]
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-26
     steps:
       - name: Set Xcode version
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: latest-stable
+          xcode-version: '26.5'
 
       - name: Checkout last commit
         uses: actions/checkout@v6

--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -4,6 +4,11 @@ jobs:
   build:
     runs-on: macos-latest
     steps:
+      - name: Set Xcode version
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
       - name: Checkout last commit
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/release-ci.yml
+++ b/.github/workflows/release-ci.yml
@@ -9,14 +9,14 @@ on:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-26
     env:
       SQUIRREL_BUNDLED_RECIPES: 'lotem/rime-octagram-data lotem/rime-octagram-data@hant'
     steps:
       - name: Set Xcode version
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: latest-stable
+          xcode-version: '26.5'
 
       - name: Checkout last commit
         uses: actions/checkout@v6

--- a/.github/workflows/release-ci.yml
+++ b/.github/workflows/release-ci.yml
@@ -13,6 +13,11 @@ jobs:
     env:
       SQUIRREL_BUNDLED_RECIPES: 'lotem/rime-octagram-data lotem/rime-octagram-data@hant'
     steps:
+      - name: Set Xcode version
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
       - name: Checkout last commit
         uses: actions/checkout@v6
         with:

--- a/sources/SquirrelPanel.swift
+++ b/sources/SquirrelPanel.swift
@@ -9,7 +9,7 @@ import AppKit
 
 final class SquirrelPanel: NSPanel {
   private let view: SquirrelView
-  private let back: NSVisualEffectView
+  private let back: NSView
   var inputController: SquirrelInputController?
 
   var position: NSRect
@@ -36,15 +36,12 @@ final class SquirrelPanel: NSPanel {
   init(position: NSRect) {
     self.position = position
     self.view = SquirrelView(frame: position)
-    self.back = NSVisualEffectView()
+    self.back = Self.makeBackgroundView()
     super.init(contentRect: position, styleMask: .nonactivatingPanel, backing: .buffered, defer: true)
     self.level = .init(Int(CGShieldingWindowLevel()))
     self.hasShadow = true
     self.isOpaque = false
     self.backgroundColor = .clear
-    back.blendingMode = .behindWindow
-    back.material = .hudWindow
-    back.state = .active
     back.wantsLayer = true
     back.layer?.mask = view.shape
     let contentView = NSView()
@@ -563,5 +560,19 @@ private extension SquirrelPanel {
     let startPos = range.lowerBound.utf16Offset(in: string)
     let endPos = range.upperBound.utf16Offset(in: string)
     return NSRange(location: startPos, length: endPos - startPos)
+  }
+
+  static func makeBackgroundView() -> NSView {
+    if #available(macOS 26.0, *) {
+      let glassView = NSGlassEffectView()
+      glassView.style = .clear
+      return glassView
+    } else {
+      let visualEffectView = NSVisualEffectView()
+      visualEffectView.blendingMode = .behindWindow
+      visualEffectView.material = .hudWindow
+      visualEffectView.state = .active
+      return visualEffectView
+    }
   }
 }


### PR DESCRIPTION
Use glass effect when user set `style/translucency` to `true` on macOS 26 and above, to match system design. On older OS, nothing will change.