### PR TITLE
Finalize stranded composition when input source is switched away programmatically (#1140)

### DIFF
--- a/sources/SquirrelApplicationDelegate.swift
+++ b/sources/SquirrelApplicationDelegate.swift
@@ -245,6 +245,7 @@ final class SquirrelApplicationDelegate: NSObject, NSApplicationDelegate, SPUSta
     notifCenter.addObserver(forName: .init("SquirrelGetASCIIModeNotification"), object: nil, queue: nil, using: rimeGetASCIIMode)
     notifCenter.addObserver(forName: .init(kTISNotifySelectedKeyboardInputSourceChanged as String), object: nil, queue: .main) { [weak self] _ in
       self?.updateStatusItemVisibility()
+      self?.finalizeStrandedComposition()
     }
   }
 
@@ -359,6 +360,19 @@ private extension SquirrelApplicationDelegate {
     guard let statusItem = statusItem else { return }
     let id = SquirrelInstaller.currentInputSourceID() ?? ""
     statusItem.isVisible = id.hasPrefix("im.rime.inputmethod.Squirrel")
+  }
+
+  // macOS 26 does not call deactivateServer when the input source is switched
+  // away by another process via TISSelectInputSource() (e.g. macism, Input
+  // Source Pro): the pending composition is stranded and the candidate panel
+  // is left orphaned on screen (#1140). The input-source-changed notification
+  // is still delivered, so finalize the composition here as a fallback.
+  // Switching via the menu bar calls deactivateServer first, making this a
+  // no-op.
+  func finalizeStrandedComposition() {
+    let id = SquirrelInstaller.currentInputSourceID() ?? ""
+    guard !id.hasPrefix("im.rime.inputmethod.Squirrel") else { return }
+    panel?.inputController?.finalizeStrandedComposition()
   }
 
   func applyStatusIcon(asciiMode: Bool, schemaLabel: String?) {

--- a/sources/SquirrelApplicationDelegate.swift
+++ b/sources/SquirrelApplicationDelegate.swift
@@ -358,8 +358,8 @@ private extension SquirrelApplicationDelegate {
 
   func updateStatusItemVisibility() {
     guard let statusItem = statusItem else { return }
-    let id = SquirrelInstaller.currentInputSourceID() ?? ""
-    statusItem.isVisible = id.hasPrefix("im.rime.inputmethod.Squirrel")
+    let currentInputSourceID = SquirrelInstaller.currentInputSourceID() ?? ""
+    statusItem.isVisible = currentInputSourceID.hasPrefix("im.rime.inputmethod.Squirrel")
   }
 
   // macOS 26 does not call deactivateServer when the input source is switched
@@ -370,8 +370,8 @@ private extension SquirrelApplicationDelegate {
   // Switching via the menu bar calls deactivateServer first, making this a
   // no-op.
   func finalizeStrandedComposition() {
-    let id = SquirrelInstaller.currentInputSourceID() ?? ""
-    guard !id.hasPrefix("im.rime.inputmethod.Squirrel") else { return }
+    let currentInputSourceID = SquirrelInstaller.currentInputSourceID() ?? ""
+    guard !currentInputSourceID.hasPrefix("im.rime.inputmethod.Squirrel") else { return }
     if let inputController = panel?.inputController {
       inputController.deactivateServer(inputController.client())
     }

--- a/sources/SquirrelApplicationDelegate.swift
+++ b/sources/SquirrelApplicationDelegate.swift
@@ -372,7 +372,9 @@ private extension SquirrelApplicationDelegate {
   func finalizeStrandedComposition() {
     let id = SquirrelInstaller.currentInputSourceID() ?? ""
     guard !id.hasPrefix("im.rime.inputmethod.Squirrel") else { return }
-    panel?.inputController?.finalizeStrandedComposition()
+    if let inputController = panel?.inputController {
+      inputController.deactivateServer(inputController.client())
+    }
   }
 
   func applyStatusIcon(asciiMode: Bool, schemaLabel: String?) {
@@ -407,7 +409,7 @@ private extension SquirrelApplicationDelegate {
   func rimeToggleASCIIMode(_ notification: Notification) {
     guard let mode = notification.object as? String else { return }
     let enableASCII = mode == "ascii"
-    
+
     if enableASCII {
       NotificationCenter.default.post(name: .init("SquirrelSetASCIIModeNotification"), object: true)
     } else {

--- a/sources/SquirrelInputController.swift
+++ b/sources/SquirrelInputController.swift
@@ -197,7 +197,7 @@ final class SquirrelInputController: IMKInputController {
     preedit = ""
     // Update menu bar icon
     if session != 0 {
-      let state = rimeAPI.get_option(session, "ascii_mode");
+      let state = rimeAPI.get_option(session, "ascii_mode")
       let label = rimeAPI.get_state_label_abbreviated(session, "ascii_mode", state, true).asString
       NSApp.squirrelAppDelegate.updateStatusIcon(asciiMode: state, schemaLabel: label)
     }
@@ -208,7 +208,7 @@ final class SquirrelInputController: IMKInputController {
     // print("[DEBUG] initWithServer: \(server ?? .init()) delegate: \(delegate ?? "nil") client:\(client ?? "nil")")
     super.init(server: server, delegate: delegate, client: client)
     createSession()
-    
+
     // Listen for ASCII mode toggle notifications
     NotificationCenter.default.addObserver(
       forName: .init("SquirrelSetASCIIModeNotification"),
@@ -217,7 +217,7 @@ final class SquirrelInputController: IMKInputController {
     ) { [weak self] notification in
       self?.handleASCIIModeToggle(notification)
     }
-    
+
     // Listen for ASCII mode status requests
     NotificationCenter.default.addObserver(
       forName: .init("SquirrelReportASCIIModeNotification"),
@@ -226,8 +226,6 @@ final class SquirrelInputController: IMKInputController {
     ) { [weak self] notification in
       self?.reportASCIIMode(notification)
     }
-    
-
   }
 
   override func deactivateServer(_ sender: Any!) {
@@ -235,18 +233,6 @@ final class SquirrelInputController: IMKInputController {
     hidePalettes()
     commitComposition(sender)
     client = nil
-  }
-
-  /// Commit the pending composition and hide the panel, mirroring
-  /// `deactivateServer`. macOS 26 does not call `deactivateServer` when the
-  /// input source is switched away by another process via
-  /// `TISSelectInputSource()` (#1140), so this is invoked from the
-  /// input-source-changed notification as a fallback. No-op when nothing is
-  /// being composed.
-  func finalizeStrandedComposition() {
-    guard session != 0, let input = rimeAPI.get_input(session), input.pointee != 0 else { return }
-    hidePalettes()
-    commitComposition(nil)
   }
 
   override func hidePalettes() {
@@ -649,27 +635,26 @@ private extension SquirrelInputController {
   private func handleASCIIModeToggle(_ notification: Notification) {
     guard let enableASCII = notification.object as? Bool else { return }
     guard session != 0 && rimeAPI.find_session(session) else { return }
-    
+
     rimeAPI.set_option(session, "ascii_mode", enableASCII)
-    
+
     // Force update the UI to reflect the mode change
     rimeUpdate()
   }
-  
+
   private func reportASCIIMode(_: Notification) {
     // Only active input controller should respond
     guard let client = client else { return }
     guard session != 0 && rimeAPI.find_session(session) else { return }
-    
+
     let isASCIIMode = rimeAPI.get_option(session, "ascii_mode")
     let status = isASCIIMode ? "ascii" : "nascii"
-    
+
     // Directly respond with the status
     DistributedNotificationCenter.default().postNotificationName(
-      .init("SquirrelASCIIModeResponse"), 
+      .init("SquirrelASCIIModeResponse"),
       object: status
     )
   }
-
 
 }

--- a/sources/SquirrelInputController.swift
+++ b/sources/SquirrelInputController.swift
@@ -237,6 +237,18 @@ final class SquirrelInputController: IMKInputController {
     client = nil
   }
 
+  /// Commit the pending composition and hide the panel, mirroring
+  /// `deactivateServer`. macOS 26 does not call `deactivateServer` when the
+  /// input source is switched away by another process via
+  /// `TISSelectInputSource()` (#1140), so this is invoked from the
+  /// input-source-changed notification as a fallback. No-op when nothing is
+  /// being composed.
+  func finalizeStrandedComposition() {
+    guard session != 0, let input = rimeAPI.get_input(session), input.pointee != 0 else { return }
+    hidePalettes()
+    commitComposition(nil)
+  }
+
   override func hidePalettes() {
     NSApp.squirrelAppDelegate.panel?.hide()
     super.hidePalettes()


### PR DESCRIPTION
Fixes #1140

**TL;DR (EN):** On macOS 26, switching the input source away from Squirrel via an out-of-process `TISSelectInputSource()` never triggers `deactivateServer`, stranding the pending composition with an orphaned candidate panel. The `kTISNotifySelectedKeyboardInputSourceChanged` notification *is* still delivered (verified in #1140), so this PR hooks the existing observer to finalize the composition — commit raw input + hide the panel, exactly what `deactivateServer` would have done.

实现说明（如 #1140 讨论的方案）：

- `SquirrelInputController.finalizeStrandedComposition()`：仅当 session 确有未上屏编码时动作，动作与 `deactivateServer` 一致（`hidePalettes()` + `commitComposition`，即原始编码上屏）；
- `SquirrelApplicationDelegate` 复用 `addObservers()` 里**已有的** `kTISNotifySelectedKeyboardInputSourceChanged` observer，多调一行：当前选中源已非鼠须管时，让 `panel.inputController`（`showPanel` 时即指向正在 composing 的 controller）收口；
- 正常路径（菜单栏切换，`deactivateServer` 已触发）下 composition 已空，整个调用是 no-op，不改变现有行为。

**验证计划**：我手头有 #1140 用的自动化复现 harness（GUI 模拟输入 + CGWindowList 候选框窗口探针 + 程序化/菜单栏双路径对照）。等 CI 出包后我会在 macOS 26.5.1 实机装包跑修复前后对照，把结果贴在这里，然后转出 draft。
