### PR TITLE
fix(ui): follow-up fixes for the ascii_mode status icon

### DIFF
--- a/sources/SquirrelApplicationDelegate.swift
+++ b/sources/SquirrelApplicationDelegate.swift
@@ -236,10 +236,13 @@ final class SquirrelApplicationDelegate: NSObject, NSApplicationDelegate, SPUSta
     notifCenter.addObserver(forName: .init("SquirrelSyncNotification"), object: nil, queue: nil, using: rimeNeedsSync)
     notifCenter.addObserver(forName: .init("SquirrelToggleASCIIModeNotification"), object: nil, queue: nil, using: rimeToggleASCIIMode)
     notifCenter.addObserver(forName: .init("SquirrelGetASCIIModeNotification"), object: nil, queue: nil, using: rimeGetASCIIMode)
-    notifCenter.addObserver(forName: .init(kTISNotifySelectedKeyboardInputSourceChanged as String), object: nil, queue: .main) { [weak self] _ in
-      self?.updateStatusItemVisibility()
-      self?.finalizeStrandedComposition()
-    }
+    // Suspension behavior matters: the default coalescing holds notifications
+    // back while the process is inactive, which is exactly the state Squirrel
+    // enters when the user switches away — the icon would fail to hide until
+    // the next activation. Deliver immediately instead.
+    notifCenter.addObserver(self, selector: #selector(inputSourceChanged(_:)),
+                            name: .init(kTISNotifySelectedKeyboardInputSourceChanged as String),
+                            object: nil, suspensionBehavior: .deliverImmediately)
   }
 
   func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
@@ -359,6 +362,13 @@ private extension SquirrelApplicationDelegate {
     statusItem = item
     applyStatusIcon(asciiMode: false, schemaLabel: nil)
     updateStatusItemVisibility()
+  }
+
+  @objc func inputSourceChanged(_: Notification) {
+    DispatchQueue.main.async { [weak self] in
+      self?.updateStatusItemVisibility()
+      self?.finalizeStrandedComposition()
+    }
   }
 
   func updateStatusItemVisibility() {

--- a/sources/SquirrelInputController.swift
+++ b/sources/SquirrelInputController.swift
@@ -177,6 +177,17 @@ final class SquirrelInputController: IMKInputController {
     if keyboardLayout != "" {
       client?.overrideKeyboard(withKeyboardNamed: keyboardLayout)
     }
+    // Activation delivers no flagsChanged event, and NSEvent.modifierFlags
+    // only reflects this process's own event stream, so lastModifiers may
+    // disagree with the actual Caps Lock state by now. Seed it from the
+    // session-wide hardware state; otherwise the next Caps Lock press can
+    // compare equal to the stale lastModifiers and be dropped by the
+    // early-return in handle().
+    if CGEventSource.flagsState(.combinedSessionState).contains(.maskAlphaShift) {
+      lastModifiers.insert(.capsLock)
+    } else {
+      lastModifiers.remove(.capsLock)
+    }
     preedit = ""
     if session != 0 {
       let state = rimeAPI.get_option(session, "ascii_mode")


### PR DESCRIPTION
## Summary

Two follow-up fixes for the menu-bar status icon introduced in #1122, found while testing across input-source switches.

### 1. Keep status icon and modifier state in sync on activation

Switching to Squirrel produces no `flagsChanged` event, so state established while another input source was active goes unnoticed:

- `lastModifiers` may hold a stale Caps Lock bit; the user's first Caps Lock press after switching in then compares equal to it and is swallowed by the early-return in `handle()`. Seed the bit from `CGEventSource.flagsState(.combinedSessionState)` — `NSEvent.modifierFlags` only reflects this process's own event stream and is stale at activation time.
- Sessions are torn down and rebuilt around input-source switches, and a fresh session initializes its options from the schema's `switches/@N/reset` without firing any option notification — the icon keeps showing the pre-switch state while the session actually starts in the reset state (the icon says 中 while typing produces English). Repaint the icon silently from the actual state on every activation. `set_option` is deliberately not used for this: re-asserting an option fires the notification and would flash the status bubble on every app switch. Nor is `ascii_mode` ever written from an observed Caps Lock — macOS clears Caps Lock whenever the input source changes, so a Caps Lock seen at activation is transient and acting on it would race that clearing.

### 2. Hide the status icon reliably when switching away from Squirrel

The block-based `addObserver(forName:object:queue:using:)` on `DistributedNotificationCenter` registers with a suspension behavior that holds notifications back while the process is not active — which is precisely Squirrel's state right after the user switches to another input source. The "hide now" notification sat undelivered until the next activation, so the icon lingered in the menu bar while ABC was selected. Register selector-based with `suspensionBehavior: .deliverImmediately` instead; the handler also keeps performing the #1140 stranded-composition cleanup.

## Testing

- Toggling Shift / Caps Lock within Squirrel updates the icon as before.
- Switching Squirrel → ABC hides the icon immediately; ABC → Squirrel shows it with the session's true mode and schema label.
- Fresh sessions (relaunch, input-source round-trips) show the schema's reset state truthfully — no more 中-icon-but-English-typing.
- With `show_notifications_when: appropriate`, no status-bubble flashes on app switches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
