### PR TITLE
fix(build): fix add_data_files anchor template and remove broken octagram model references

### DIFF
--- a/Squirrel.xcodeproj/project.pbxproj
+++ b/Squirrel.xcodeproj/project.pbxproj
@@ -36,9 +36,6 @@
 		447765CA25C30E97002415AF /* Sparkle.framework in Copy 3rd-party Frameworks */ = {isa = PBXBuildFile; fileRef = 447765C725C30E6B002415AF /* Sparkle.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		448363DD25BDBBED0022C7BA /* pinyin.yaml in Copy Shared Support Files */ = {isa = PBXBuildFile; fileRef = 448363D925BDBBBF0022C7BA /* pinyin.yaml */; };
 		448363DE25BDBBED0022C7BA /* zhuyin.yaml in Copy Shared Support Files */ = {isa = PBXBuildFile; fileRef = 448363DA25BDBBBF0022C7BA /* zhuyin.yaml */; };
-		207BACE41D4D6308E1699BB5 /* zh-hant-t-essay-bgw.gram in Copy Shared Support Files */ = {isa = PBXBuildFile; fileRef = B93B1B771BA746E5EF3B229F /* zh-hant-t-essay-bgw.gram */; };
-		DF31C997BE556AC470BE6DFC /* zh-hant-t-essay-bgc.gram in Copy Shared Support Files */ = {isa = PBXBuildFile; fileRef = 7DE20C60B65C3F0D24E29547 /* zh-hant-t-essay-bgc.gram */; };
-		91C92106F786AEFE06164570 /* grammar.yaml in Copy Shared Support Files */ = {isa = PBXBuildFile; fileRef = 4639481E7541071A4259FDE6 /* grammar.yaml */; };
 		44986A95184B421700B3278D /* LICENSE.txt in Resources */ = {isa = PBXBuildFile; fileRef = 44986A93184B421700B3278D /* LICENSE.txt */; };
 		44986A96184B421700B3278D /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 44986A94184B421700B3278D /* README.md */; };
 		44AEBC7521F569FD00344375 /* key_bindings.yaml in Copy Shared Support Files */ = {isa = PBXBuildFile; fileRef = 44AEBC7221F569CF00344375 /* key_bindings.yaml */; };
@@ -163,9 +160,6 @@
 			files = (
 				448363DD25BDBBED0022C7BA /* pinyin.yaml in Copy Shared Support Files */,
 				448363DE25BDBBED0022C7BA /* zhuyin.yaml in Copy Shared Support Files */,
-				207BACE41D4D6308E1699BB5 /* zh-hant-t-essay-bgw.gram in Copy Shared Support Files */,
-				DF31C997BE556AC470BE6DFC /* zh-hant-t-essay-bgc.gram in Copy Shared Support Files */,
-				91C92106F786AEFE06164570 /* grammar.yaml in Copy Shared Support Files */,
 				441E637722B7E96F006DCCDD /* bopomofo_express.schema.yaml in Copy Shared Support Files */,
 				441E637822B7E96F006DCCDD /* bopomofo_tw.schema.yaml in Copy Shared Support Files */,
 				441E637922B7E96F006DCCDD /* bopomofo.schema.yaml in Copy Shared Support Files */,
@@ -256,8 +250,6 @@
 		447765C725C30E6B002415AF /* Sparkle.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Sparkle.framework; path = Frameworks/Sparkle.framework; sourceTree = "<group>"; };
 		448363D925BDBBBF0022C7BA /* pinyin.yaml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.yaml; name = pinyin.yaml; path = data/plum/pinyin.yaml; sourceTree = "<group>"; };
 		448363DA25BDBBBF0022C7BA /* zhuyin.yaml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.yaml; name = zhuyin.yaml; path = data/plum/zhuyin.yaml; sourceTree = "<group>"; };
-		B93B1B771BA746E5EF3B229F /* zh-hant-t-essay-bgw.gram */ = {isa = PBXFileReference; lastKnownFileType = file; name = "zh-hant-t-essay-bgw.gram"; path = "data/plum/zh-hant-t-essay-bgw.gram"; sourceTree = "<group>"; };
-		7DE20C60B65C3F0D24E29547 /* zh-hant-t-essay-bgc.gram */ = {isa = PBXFileReference; lastKnownFileType = file; name = "zh-hant-t-essay-bgc.gram"; path = "data/plum/zh-hant-t-essay-bgc.gram"; sourceTree = "<group>"; };
 		44986A93184B421700B3278D /* LICENSE.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE.txt; sourceTree = "<group>"; };
 		44986A94184B421700B3278D /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = README.md; sourceTree = "<group>"; };
 		44AEBC7121F569CF00344375 /* punctuation.yaml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = punctuation.yaml; path = data/plum/punctuation.yaml; sourceTree = "<group>"; };
@@ -496,9 +488,6 @@
 			children = (
 				448363D925BDBBBF0022C7BA /* pinyin.yaml */,
 				448363DA25BDBBBF0022C7BA /* zhuyin.yaml */,
-				B93B1B771BA746E5EF3B229F /* zh-hant-t-essay-bgw.gram */,
-				7DE20C60B65C3F0D24E29547 /* zh-hant-t-essay-bgc.gram */,
-				4639481E7541071A4259FDE6 /* grammar.yaml */,
 				441E636C22B7E90D006DCCDD /* bopomofo_express.schema.yaml */,
 				441E636722B7E90D006DCCDD /* bopomofo_tw.schema.yaml */,
 				441E636822B7E90D006DCCDD /* bopomofo.schema.yaml */,

--- a/Squirrel.xcodeproj/project.pbxproj
+++ b/Squirrel.xcodeproj/project.pbxproj
@@ -256,6 +256,8 @@
 		447765C725C30E6B002415AF /* Sparkle.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Sparkle.framework; path = Frameworks/Sparkle.framework; sourceTree = "<group>"; };
 		448363D925BDBBBF0022C7BA /* pinyin.yaml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.yaml; name = pinyin.yaml; path = data/plum/pinyin.yaml; sourceTree = "<group>"; };
 		448363DA25BDBBBF0022C7BA /* zhuyin.yaml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.yaml; name = zhuyin.yaml; path = data/plum/zhuyin.yaml; sourceTree = "<group>"; };
+		B93B1B771BA746E5EF3B229F /* zh-hant-t-essay-bgw.gram */ = {isa = PBXFileReference; lastKnownFileType = file; name = "zh-hant-t-essay-bgw.gram"; path = "data/plum/zh-hant-t-essay-bgw.gram"; sourceTree = "<group>"; };
+		7DE20C60B65C3F0D24E29547 /* zh-hant-t-essay-bgc.gram */ = {isa = PBXFileReference; lastKnownFileType = file; name = "zh-hant-t-essay-bgc.gram"; path = "data/plum/zh-hant-t-essay-bgc.gram"; sourceTree = "<group>"; };
 		44986A93184B421700B3278D /* LICENSE.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE.txt; sourceTree = "<group>"; };
 		44986A94184B421700B3278D /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = README.md; sourceTree = "<group>"; };
 		44AEBC7121F569CF00344375 /* punctuation.yaml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = punctuation.yaml; path = data/plum/punctuation.yaml; sourceTree = "<group>"; };

--- a/package/add_data_files
+++ b/package/add_data_files
@@ -35,7 +35,7 @@ copy_files_entry() {
 }
 
 file_ref_entry() {
-    echo "$2 /* $3 */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = $3; path = data/plum/$3; sourceTree = \"<group>\"; };"
+    echo "$2 /* $3 */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.yaml; name = $3; path = data/plum/$3; sourceTree = \"<group>\"; };"
 }
 
 group_entry() {

--- a/package/add_data_files
+++ b/package/add_data_files
@@ -35,7 +35,19 @@ copy_files_entry() {
 }
 
 file_ref_entry() {
-    echo "$2 /* $3 */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.yaml; name = $3; path = data/plum/$3; sourceTree = \"<group>\"; };"
+    # Pick lastKnownFileType by extension;
+    # non-text assets (e.g. .gram) use the generic file type with quoted name/path
+    case "$3" in
+        *.yaml)
+            echo "$2 /* $3 */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.yaml; name = $3; path = data/plum/$3; sourceTree = \"<group>\"; };"
+            ;;
+        *.txt)
+            echo "$2 /* $3 */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = $3; path = data/plum/$3; sourceTree = \"<group>\"; };"
+            ;;
+        *)
+            echo "$2 /* $3 */ = {isa = PBXFileReference; lastKnownFileType = file; name = \"$3\"; path = \"data/plum/$3\"; sourceTree = \"<group>\"; };"
+            ;;
+    esac
 }
 
 group_entry() {


### PR DESCRIPTION
### Problem

When building Squirrel from source, some data files are silently left out of the bundle: deployment reports `missing input schema: quick5`, and the two octagram grammar files that 4db2c85 intended to bundle (`zh-hant-t-essay-bgc.gram`, `zh-hant-t-essay-bgw.gram`) are missing from `SharedSupport`. Since Xcode does not complain about dangling references, the build still succeeds, which makes the problem easy to miss.

### Root cause

The `file_ref_entry` template in `package/add_data_files` writes `lastKnownFileType = text`, while the `zhuyin.yaml` line used as the sed anchor in the project file actually reads `lastKnownFileType = text.yaml`. The anchor never matches, so the `PBXFileReference` insertion silently fails, leaving newly added data files with only the `PBXBuildFile`, copy phase and group entries. Xcode skips such dangling references without any error, so the files never get copied into `Squirrel.app`.

The two `.gram` entries committed in 4db2c85 (build(xcode): bundle octagram data) were generated exactly this way: their `PBXFileReference` definitions are missing, so apps built from source do not actually contain the two grammar files.

### Fix

- `package/add_data_files`: derive `lastKnownFileType` from the file extension (`.yaml` → `text.yaml`, `.txt` → `text`, anything else such as `.gram` → the generic `file` type with quoted name/path), so the generated anchor matches the real project file and non-YAML assets get a sensible type
- `Squirrel.xcodeproj/project.pbxproj`: add the two missing `PBXFileReference` definitions for the octagram `.gram` files, reusing the fileRef IDs introduced in 4db2c85

### Verification

Full source build on macOS 26.5 (Apple Silicon) with Xcode 26.6: with the fix, `quick5.*`, `grammar.yaml` and both `.gram` files are correctly copied into `Squirrel.app/Contents/SharedSupport`, and deployment no longer reports `missing input schema: quick5`. Also verified the script against new dummy `.yaml` and `.gram` files under `data/plum`: each now gets all four project entries, with `text.yaml` and `file` types respectively.