### PR TITLE
fix: correct input method installation path in SquirrelApp.appDir

### DIFF
--- a/sources/Main.swift
+++ b/sources/Main.swift
@@ -15,7 +15,7 @@ struct SquirrelApp {
   } else {
     try! FileManager.default.url(for: .libraryDirectory, in: .userDomainMask, appropriateFor: nil, create: false).appendingPathComponent("Rime", isDirectory: true)
   }
-  static let appDir = "/Library/Input Library/Squirrel.app".withCString { dir in
+  static let appDir = "/Library/Input Methods/Squirrel.app".withCString { dir in
     URL(fileURLWithFileSystemRepresentation: dir, isDirectory: false, relativeTo: nil)
   }
   static let logDir = FileManager.default.temporaryDirectory.appending(component: "rime.squirrel", directoryHint: .isDirectory)


### PR DESCRIPTION
### Problem

`SquirrelApp.appDir` in `sources/Main.swift` has read `/Library/Input Library/Squirrel.app` since the Swift migration (ce4f761, #898):

```swift
static let appDir = "/Library/Input Library/Squirrel.app".withCString { dir in
```

The standard input method location is `/Library/Input Methods/Squirrel.app`, which is also where the Makefile and the installer actually place the app. As a result, `TISRegisterInputSource(SquirrelApp.appDir)` in `--register-input-source` points at a nonexistent path, so explicit (re-)registration has been silently broken for every Swift-era release.

### Why it went unnoticed

- On systems where Squirrel is already enabled, `SquirrelInstaller.register()` returns early before ever calling `TISRegisterInputSource`.
- On fresh systems, macOS auto-discovers input methods placed under `/Library/Input Methods`, so installation still appears to work without explicit registration.

The breakage only shows when re-registration actually matters, e.g. re-registering after the app bundle has been replaced by a from-source reinstall.

### Fix

Correct the path to `/Library/Input Methods/Squirrel.app`.