### PR TITLE
fix: post CLI control notifications with deliverImmediately

### DIFF
--- a/sources/Main.swift
+++ b/sources/Main.swift
@@ -35,7 +35,9 @@ struct SquirrelApp {
           runningSquirrels.forEach { $0.terminate() }
           return true
         case "--reload":
-          DistributedNotificationCenter.default().postNotificationName(.init("SquirrelReloadNotification"), object: nil)
+          // Squirrel is a background app, and AppKit suspends distributed-notification delivery to inactive apps;
+          // deliverImmediately is required for these notifications to reach Squirrel while it stays in the background
+          DistributedNotificationCenter.default().postNotificationName(.init("SquirrelReloadNotification"), object: nil, userInfo: nil, deliverImmediately: true)
           return true
         case "--register-input-source", "--install":
           installer.register()
@@ -76,13 +78,13 @@ struct SquirrelApp {
           _ = rimeAPI.deploy()
           return true
         case "--sync":
-          DistributedNotificationCenter.default().postNotificationName(.init("SquirrelSyncNotification"), object: nil)
+          DistributedNotificationCenter.default().postNotificationName(.init("SquirrelSyncNotification"), object: nil, userInfo: nil, deliverImmediately: true)
           return true
         case "--ascii":
-          DistributedNotificationCenter.default().postNotificationName(.init("SquirrelToggleASCIIModeNotification"), object: "ascii")
+          DistributedNotificationCenter.default().postNotificationName(.init("SquirrelToggleASCIIModeNotification"), object: "ascii", userInfo: nil, deliverImmediately: true)
           return true
         case "--nascii":
-          DistributedNotificationCenter.default().postNotificationName(.init("SquirrelToggleASCIIModeNotification"), object: "nascii")
+          DistributedNotificationCenter.default().postNotificationName(.init("SquirrelToggleASCIIModeNotification"), object: "nascii", userInfo: nil, deliverImmediately: true)
           return true
         case "--getascii":
           var responseReceived = false
@@ -97,7 +99,7 @@ struct SquirrelApp {
               responseReceived = true
             }
           }
-          DistributedNotificationCenter.default().postNotificationName(.init("SquirrelGetASCIIModeNotification"), object: nil)
+          DistributedNotificationCenter.default().postNotificationName(.init("SquirrelGetASCIIModeNotification"), object: nil, userInfo: nil, deliverImmediately: true)
           let timeout = Date().addingTimeInterval(2.0)
           while !responseReceived && Date() < timeout {
             RunLoop.current.run(until: Date().addingTimeInterval(0.01))


### PR DESCRIPTION
## Problem

`squirrel --reload`, `--sync`, `--ascii`, `--nascii` and `--getascii` frequently do nothing, while the corresponding menu items always work.

## Root cause

These CLI options communicate with the running Squirrel instance via distributed notifications. AppKit suspends distributed-notification delivery to applications while they are inactive, and Squirrel — a background input-method app — is virtually always inactive. Since `postNotificationName(_:object:)` defaults to `deliverImmediately: false`, the posted notification respects the receiver's suspension and gets queued or dropped instead of delivered; occasionally it arrives late when Squirrel briefly becomes active, which makes the commands appear flaky rather than broken. The menu items are unaffected because they invoke the same handlers in-process.

Verified on macOS 26.5: `squirrel --sync` leaves no trace in `rime.squirrel.INFO`, while posting the same notification with `deliverImmediately: true` triggers the sync within a second.

## Fix

Post all five CLI control notifications with `deliverImmediately: true`, which is documented to bypass the receiver's suspension behavior.