### PR TITLE
fix: support direct commits in marked text clients

### DIFF
--- a/data/squirrel.yaml
+++ b/data/squirrel.yaml
@@ -400,6 +400,9 @@ app_options:
   com.apple.Terminal:
     ascii_mode: true
     no_inline: true
+  org.alacritty:
+    # Work around https://github.com/rime/squirrel/issues/741
+    force_marked_text_for_direct_commit: true
   com.googlecode.iterm2:
     ascii_mode: true
     no_inline: true

--- a/package/add_data_files
+++ b/package/add_data_files
@@ -124,11 +124,11 @@ add_lib() {
 }
 
 data_files=(
-    $(ls data/plum/* | xargs basename)
+    $(for file in data/plum/*; do basename "$file"; done)
 )
 
 lib_files=(
-    $(ls lib/rime-plugins/* | xargs basename)
+    $(for file in lib/rime-plugins/*; do basename "$file"; done)
 )
 
 for file in "${data_files[@]}"

--- a/sources/SquirrelInputController.swift
+++ b/sources/SquirrelInputController.swift
@@ -561,6 +561,23 @@ private extension SquirrelInputController {
 
   func commit(string: String) {
     guard let client = client else { return }
+
+    let forceMarkedText =
+      session != 0 &&
+      rimeAPI.get_option(session, "force_marked_text_for_direct_commit")
+
+    // Direct commits such as full-width punctuation do not necessarily have an
+    // active marked-text phase. Some NSTextInputClient implementations require
+    // one before accepting insertText.
+    if forceMarkedText && preedit.isEmpty && !string.isEmpty {
+      let markedText = NSMutableAttributedString(string: string)
+      client.setMarkedText(
+        markedText,
+        selectionRange: NSRange(location: markedText.length, length: 0),
+        replacementRange: .empty
+      )
+    }
+
     client.insertText(string, replacementRange: .empty)
     preedit = ""
     hidePalettes()


### PR DESCRIPTION
## Summary

- synthesize a marked-text phase before direct Rime commits when enabled per app
- preserve the normal preedit path and scope the workaround to `force_marked_text_for_direct_commit`
- enable the workaround for Alacritty (`org.alacritty`)
- make package data-file enumeration compatible with macOS `basename`

Closes #741