### PR TITLE
feat(SquirrelTheme): allow customizing preedit area font

### DIFF
--- a/data/squirrel.yaml
+++ b/data/squirrel.yaml
@@ -72,6 +72,8 @@ style:
   #label_font_point: 12
   #comment_font_face: 'Avenir'
   #comment_font_point: 16
+  #preedit_font_face: 'Avenir'
+  #preedit_font_point: 16
 
 preset_color_schemes:
   native:

--- a/sources/SquirrelTheme.swift
+++ b/sources/SquirrelTheme.swift
@@ -73,9 +73,11 @@ final class SquirrelTheme {
   private var fonts = [NSFont]()
   private var labelFonts = [NSFont]()
   private var commentFonts = [NSFont]()
+  private var preeditFonts = [NSFont]()
   private var fontSize: CGFloat?
   private var labelFontSize: CGFloat?
   private var commentFontSize: CGFloat?
+  private var preeditFontSize: CGFloat?
 
   private var _candidateFormat = "[label]. [candidate] [comment]"
   private(set) var statusMessageType: StatusMessageType = .mix
@@ -102,6 +104,15 @@ final class SquirrelTheme {
     if let font = combineFonts(commentFonts, size: commentFontSize ?? fontSize) {
       return font
     } else if let size = commentFontSize {
+      return self.font.withSize(size)
+    } else {
+      return self.font
+    }
+  }()
+  private(set) lazy var preeditFont: NSFont = {
+    if let font = combineFonts(preeditFonts, size: preeditFontSize ?? fontSize) {
+      return font
+    } else if let size = preeditFontSize {
       return self.font.withSize(size)
     } else {
       return self.font
@@ -139,12 +150,12 @@ final class SquirrelTheme {
   ]
   private(set) lazy var preeditAttrs: [NSAttributedString.Key: Any] = [
     .foregroundColor: textColor,
-    .font: font,
+    .font: preeditFont,
     .baselineOffset: baseOffset
   ]
   private(set) lazy var preeditHighlightedAttrs: [NSAttributedString.Key: Any] = [
     .foregroundColor: highlightedTextColor,
-    .font: font,
+    .font: preeditFont,
     .baselineOffset: baseOffset
   ]
 
@@ -224,6 +235,8 @@ final class SquirrelTheme {
     var labelFontSize = config.getDouble("style/label_font_point")
     var commentFontName = config.getString("style/comment_font_face")
     var commentFontSize = config.getDouble("style/comment_font_point")
+    var preeditFontName = config.getString("style/preedit_font_face")
+    var preeditFontSize = config.getDouble("style/preedit_font_point")
 
     let colorSchemeOption = dark ? "style/color_scheme_dark" : "style/color_scheme"
     if let colorScheme = config.getString(colorSchemeOption) {
@@ -264,6 +277,8 @@ final class SquirrelTheme {
         labelFontSize ?= config.getDouble("\(prefix)/label_font_point")
         commentFontName ?= config.getString("\(prefix)/comment_font_face")
         commentFontSize ?= config.getDouble("\(prefix)/comment_font_point")
+        preeditFontName ?= config.getString("\(prefix)/preedit_font_face")
+        preeditFontSize ?= config.getDouble("\(prefix)/preedit_font_point")
 
         alpha ?= config.getDouble("\(prefix)/alpha").map { max(0, min(1, $0)) }
         cornerRadius ?= config.getDouble("\(prefix)/corner_radius")
@@ -286,6 +301,8 @@ final class SquirrelTheme {
     self.labelFontSize = labelFontSize
     commentFonts = decodeFonts(from: commentFontName ?? fontName)
     self.commentFontSize = commentFontSize
+    preeditFonts = decodeFonts(from: preeditFontName ?? fontName)
+    self.preeditFontSize = preeditFontSize
   }
 }
 


### PR DESCRIPTION
## 问题
现有的字形 fallback 是按字形覆盖选字体的，无法按界面区域区分。当同一种文字同时出现在 preedit 和候选区时(例如中英混输时两边都有拉丁字母)，就没办法只改其中一个区域的字体。preedit 也无法单独设置字体大小而只是跟随全局的`style/font_point`

## 解决
新增两个 style 配置项,让 preedit 区域的字体可以独立于候选区域设置字体和大小:

- `style/preedit_font_face`
- `style/preedit_font_point`

未设置时回退到 `style/font_face` / `style/font_point`。实现方式与已有的 `label_font_*` / `comment_font_*` 相同,同样支持在配色方案中覆盖。

## 配置
情况一：
```yaml
  "style/font_face": "Source Han Sans SC-Bold"
  "style/font_point": 20
  ...
  "style/preedit_font_face": "JetBrains Mono-light"
  "style/preedit_font_point": 24
```
情况二：
```yaml
  "style/font_face": "Source Han Sans SC-Bold"
  "style/font_point": 20
  ...
  # "style/preedit_font_face": "JetBrains Mono-light"
  "style/preedit_font_point": 16
```

## 效果
情况一：
<img width="306" height="296" alt="image" src="https://github.com/user-attachments/assets/ba16092f-d98e-45a1-b910-8e5b27f31e03" />

情况二：
<img width="306" height="270" alt="image" src="https://github.com/user-attachments/assets/c3cc7272-c37e-4346-9a57-b5bf92684800" />

