### PR TITLE
fix(input): handle panelless direct commits reliably

### DIFF
--- a/data/squirrel.yaml
+++ b/data/squirrel.yaml
@@ -402,6 +402,7 @@ app_options:
     no_inline: true
   org.alacritty:
     # Work around https://github.com/rime/squirrel/issues/741
+    # Needs a marked-text phase before panelless insertText (e.g. full-width punct).
     force_marked_text_for_direct_commit: true
   com.googlecode.iterm2:
     ascii_mode: true

--- a/data/squirrel.yaml
+++ b/data/squirrel.yaml
@@ -420,6 +420,10 @@ app_options:
     ascii_mode: true
   com.microsoft.VSCode:
     ascii_mode: true
+    # Integrated terminal (xterm.js) drops panelless insertText during keyDown.
+    # Mark first, then insert on the next runloop turn.
+    force_marked_text_for_direct_commit: true
+    defer_direct_commit: true
   com.sublimetext.2:
     ascii_mode: true
   org.gnu.Aquamacs:

--- a/sources/SquirrelInputController.swift
+++ b/sources/SquirrelInputController.swift
@@ -27,6 +27,10 @@ final class SquirrelInputController: IMKInputController {
   private var chordTimer: Timer?
   private var chordDuration: TimeInterval = 0
   private var currentApp: String = ""
+  // Tracks a synthetic marked range created for panelless direct commits.
+  // Some clients (Alacritty) keep it active after insertText; the next key
+  // would otherwise only cancel composition instead of performing its action.
+  private var hasSyntheticMarkedText = false
 
   // swiftlint:disable:next cyclomatic_complexity
   override func handle(_ event: NSEvent!, client sender: Any!) -> Bool {
@@ -112,6 +116,11 @@ final class SquirrelInputController: IMKInputController {
         if rimeKeycode != 0 {
           let rimeModifiers = SquirrelKeycode.osxModifiersToRime(modifiers: modifiers)
           handled = processKey(rimeKeycode, modifiers: rimeModifiers)
+          if !handled && hasSyntheticMarkedText {
+            // Clear residual composition so the client can handle this key
+            // (e.g. first Backspace after a full-width punctuation commit).
+            clearSyntheticMarkedText()
+          }
           rimeUpdate()
         }
       }
@@ -166,6 +175,7 @@ final class SquirrelInputController: IMKInputController {
 
   override func activateServer(_ sender: Any!) {
     self.client ?= sender as? IMKTextInput
+    hasSyntheticMarkedText = false
     var keyboardLayout = NSApp.squirrelAppDelegate.config?.getString("keyboard_layout") ?? ""
     if keyboardLayout == "last" || keyboardLayout == "" {
       keyboardLayout = ""
@@ -586,17 +596,37 @@ private extension SquirrelInputController {
         selectionRange: NSRange(location: markedText.length, length: 0),
         replacementRange: .empty
       )
+      hasSyntheticMarkedText = true
     }
 
     if deferDirectCommit {
-      DispatchQueue.main.async { [weak client] in
+      DispatchQueue.main.async { [weak self, weak client] in
         client?.insertText(string, replacementRange: .empty)
+        self?.clearSyntheticMarkedText()
       }
     } else {
       client.insertText(string, replacementRange: .empty)
+      // Alacritty often ignores a same-turn empty setMarkedText after insertText.
+      // Clear on the next runloop turn; unhandled keys also clear as a fallback.
+      if forceMarkedText {
+        DispatchQueue.main.async { [weak self] in
+          self?.clearSyntheticMarkedText()
+        }
+      }
     }
     preedit = ""
     hidePalettes()
+  }
+
+  func clearSyntheticMarkedText() {
+    guard hasSyntheticMarkedText else { return }
+    hasSyntheticMarkedText = false
+    guard let client = client else { return }
+    client.setMarkedText(
+      NSMutableAttributedString(string: ""),
+      selectionRange: .empty,
+      replacementRange: NSRange(location: NSNotFound, length: NSNotFound)
+    )
   }
 
   func show(preedit: String, selRange: NSRange, caretPos: Int) {
@@ -608,6 +638,11 @@ private extension SquirrelInputController {
     self.preedit = preedit
     self.caretPos = caretPos
     self.selRange = selRange
+    // A real preedit replaces any synthetic marker we may have left. An empty
+    // context refresh must keep it so the deferred cleanup can still run.
+    if !preedit.isEmpty {
+      hasSyntheticMarkedText = false
+    }
 
     let start = selRange.location
     let attrString = NSMutableAttributedString(string: preedit)

--- a/sources/SquirrelInputController.swift
+++ b/sources/SquirrelInputController.swift
@@ -562,14 +562,24 @@ private extension SquirrelInputController {
   func commit(string: String) {
     guard let client = client else { return }
 
+    // Only panelless commits (e.g. full-width punctuation) lack a preedit phase.
+    // Normal Chinese confirmation already has active marked text and must stay
+    // synchronous so later setMarkedText cleanup cannot race the insert.
+    let isDirectCommit = preedit.isEmpty && !string.isEmpty
     let forceMarkedText =
+      isDirectCommit &&
       session != 0 &&
       rimeAPI.get_option(session, "force_marked_text_for_direct_commit")
+    // Some clients (e.g. VS Code terminal / xterm.js) drop insertText delivered
+    // synchronously inside keyDown. Defer only those bare direct commits.
+    let deferDirectCommit =
+      isDirectCommit &&
+      session != 0 &&
+      rimeAPI.get_option(session, "defer_direct_commit")
 
-    // Direct commits such as full-width punctuation do not necessarily have an
-    // active marked-text phase. Some NSTextInputClient implementations require
-    // one before accepting insertText.
-    if forceMarkedText && preedit.isEmpty && !string.isEmpty {
+    // Some NSTextInputClient implementations require an active marked-text
+    // phase before accepting insertText for panelless commits.
+    if forceMarkedText {
       let markedText = NSMutableAttributedString(string: string)
       client.setMarkedText(
         markedText,
@@ -578,7 +588,13 @@ private extension SquirrelInputController {
       )
     }
 
-    client.insertText(string, replacementRange: .empty)
+    if deferDirectCommit {
+      DispatchQueue.main.async { [weak client] in
+        client?.insertText(string, replacementRange: .empty)
+      }
+    } else {
+      client.insertText(string, replacementRange: .empty)
+    }
     preedit = ""
     hidePalettes()
   }


### PR DESCRIPTION
## Summary

- defer panelless direct commits to the next main-runloop turn for the VS Code integrated terminal
- track and clear synthetic marked text so clients such as Alacritty do not consume the first unhandled key after punctuation
- preserve normal synchronous commits when a real preedit is active
- configure the workarounds only for the known affected applications

## Motivation

This is a follow-up to #1165.

VS Code's integrated terminal (xterm.js) can drop `insertText` when a panelless commit, such as full-width punctuation, is delivered synchronously during `keyDown`. Alacritty, on the other hand, needs the synthetic marked-text phase but may retain it after `insertText`, causing the first Backspace to cancel composition instead of deleting text.

The two behaviors are therefore kept independently configurable:

- `force_marked_text_for_direct_commit` synthesizes the marked-text phase
- `defer_direct_commit` moves the final insertion to the next main-runloop turn

## Default behavior

As discussed in #1165, I also tested enabling the marked-text workaround globally. The earlier implementation caused font fallback in Microsoft Word. The cleanup in this PR has fixed that issue in current testing, but broader testing is still in progress.

For now, this PR does not make the workaround global. It remains scoped through `app_options` to the known affected clients: Alacritty and VS Code.

## Testing

- tested Chinese input and full-width punctuation in Alacritty
- verified that the first Backspace after a direct punctuation commit is no longer swallowed
- tested Chinese input and full-width punctuation in the VS Code integrated terminal
- retested Microsoft Word, including the previously observed font-fallback case
- built the Debug target with `CODE_SIGNING_ALLOWED=NO` (`BUILD SUCCEEDED`)
